### PR TITLE
Change for PHP8

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -4037,11 +4037,15 @@ class DocumentParser
         }
 
         $doc = $this->getDocumentObject('id', $docid);
-        if (is_array($doc[$field])) {
-            $tvs = $this->getTemplateVarOutput($field, $docid, 1);
-            $content = $tvs[$field];
-        } else {
-            $content = $doc[$field];
+
+        $content = '';
+        if (isset($doc[$field])) {
+            if (is_array($doc[$field])) {
+                $tvs = $this->getTemplateVarOutput($field, $docid, 1);
+                $content = $tvs[$field];
+            } else {
+                $content = $doc[$field];
+            }
         }
 
         $this->tmpCache[__FUNCTION__][$cacheKey] = $content;


### PR DESCRIPTION
ex: evo runs "[*your_tmplvar@parent*]" but the parent page don't have [*your_tmplvar*] => "Error : Undefined array key [template value]" and "Error : Undefined variable $content" in PHP8.