### PR TITLE
fix: fix z-index for extras installation info

### DIFF
--- a/assets/modules/store/css/style.css
+++ b/assets/modules/store/css/style.css
@@ -92,6 +92,7 @@ body {
 }
 
 .informer {
+  z-index: 1;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
fix this problem:
![image](https://user-images.githubusercontent.com/39497333/190852931-aec6e8a6-7cc4-42c7-9e03-6ea262a8a10f.png)

to this result:
![image](https://user-images.githubusercontent.com/39497333/190853021-95e3cf3d-1dea-4b80-9040-e2b2febaef0f.png)