### PR TITLE
Update document.parser.class.inc.php

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -4256,7 +4256,7 @@ class DocumentParser
                     if ($this->config['aliaslistingfolder'] == 1  || (isset($this->config['full_aliaslisting']) && $this->config['full_aliaslisting'] == 1)) {
                         $al = $this->getAliasListing($id);
                     } else {
-                        $al = $this->aliasListing[$id];
+                        empty($aliasListing[$id]) ? $al = $this->aliasListing[$this->config['error_page']] : $al = $this->aliasListing[$id];
                     }
 
                     if ($al['isfolder'] === 1 && $this->config['make_folders'] === '1') {


### PR DESCRIPTION
makeUrl causes php error when trying to make url's with deleted documents.

This should set it error_page as the id.