### PR TITLE
bug fix - EVO::getField()

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -4081,7 +4081,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
 
         $doc = $this->getDocumentObject('id', $docid);
         if (is_array($doc[$field])) {
-            $tvs = $this->getTemplateVarOutput($field, $docid, 1);
+            $tvs = $this->getTemplateVarOutput($field, $docid, 'all');
             $content = $tvs[$field];
         } else {
             $content = $doc[$field];


### PR DESCRIPTION
For private resources, can get resource variables but template variables is empty.