### PR TITLE
Add params to dinamic properties in class for php 8.2. 

### DIFF
--- a/assets/lib/APIHelpers.class.php
+++ b/assets/lib/APIHelpers.class.php
@@ -4,7 +4,7 @@
  * Class APIhelpers
  */
 if (!class_exists('APIhelpers')) {
-
+#[AllowDynamicProperties]
 class APIhelpers
 {
 

--- a/assets/lib/Helpers/Assets.php
+++ b/assets/lib/Helpers/Assets.php
@@ -5,6 +5,7 @@ require_once(MODX_BASE_PATH . 'assets/lib/Helpers/FS.php');
 /**
  * Class AssetsHelper
  */
+#[AllowDynamicProperties] 
 class AssetsHelper
 {
     /**

--- a/assets/lib/Helpers/FS.php
+++ b/assets/lib/Helpers/FS.php
@@ -4,6 +4,7 @@
  * Class FS
  * @package Helpers
  */
+#[AllowDynamicProperties]
 class FS
 {
     /**
@@ -11,7 +12,7 @@ class FS
      */
     protected static $instance;
 
-    /**
+/**
      * @var array
      */
     private $_fileInfo = array();

--- a/assets/lib/Helpers/PHPThumb.php
+++ b/assets/lib/Helpers/PHPThumb.php
@@ -11,6 +11,7 @@ require_once(MODX_BASE_PATH . 'assets/lib/Helpers/FS.php');
  * Class PHPThumb
  * @package Helpers
  */
+#[AllowDynamicProperties]
 class PHPThumb
 {
 

--- a/assets/lib/MODxAPI/autoTable.abstract.php
+++ b/assets/lib/MODxAPI/autoTable.abstract.php
@@ -4,7 +4,8 @@ require_once('MODx.php');
 /**
  * Class autoTable
  */
-abstract class autoTable extends MODxAPI
+ #[AllowDynamicProperties]
+ abstract class autoTable extends MODxAPI
 {
     /**
      * @var null

--- a/assets/lib/SimpleTab/controller.abstract.php
+++ b/assets/lib/SimpleTab/controller.abstract.php
@@ -6,6 +6,7 @@ require_once(MODX_BASE_PATH . 'assets/lib/Helpers/FS.php');
  * Class AbstractController
  * @package SimpleTab
  */
+#[AllowDynamicProperties] 
 abstract class AbstractController
 {
     /**

--- a/assets/lib/SimpleTab/plugin.class.php
+++ b/assets/lib/SimpleTab/plugin.class.php
@@ -10,6 +10,7 @@ require_once(MODX_BASE_PATH . 'assets/lib/Helpers/Assets.php');
  * Class Plugin
  * @package SimpleTab
  */
+#[AllowDynamicProperties] 
 abstract class Plugin
 {
     /**

--- a/assets/lib/SimpleTab/table.abstract.php
+++ b/assets/lib/SimpleTab/table.abstract.php
@@ -8,6 +8,7 @@ require_once(MODX_BASE_PATH . 'assets/lib/Helpers/PHPThumb.php');
  * Class dataTable
  * @package SimpleTab
  */
+#[AllowDynamicProperties] 
 class dataTable extends \autoTable
 {
     /**

--- a/assets/lib/class.modxRTEbridge.php
+++ b/assets/lib/class.modxRTEbridge.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * @author Deesen, yama / updated: 27.01.2018
+ * @author Deesen, yama / updated: 16.02.2023
  */
 if (!defined('MODX_BASE_PATH')) {
     die('What are you doing? Get out of here!');
 }
-
+#[AllowDynamicProperties]
 class modxRTEbridge
 {
     public $pluginName = '';                    // Name of plugin - nessecary to retrieve plugin-configuration by connectors
@@ -836,15 +836,27 @@ class modxRTEbridge
     public function mergeParamArrays()
     {
         $p = array();
-        foreach($this->pluginParams as $param=>$value) { $p['pp.'.$param] = is_array($value) ? implode(',',$value) : $value; }
-        foreach($this->modxParams   as $param=>$value) { $p['mp.'.$param] = is_array($value) ? implode(',',$value) : $value; }
+		
+		//hack to php 8.2
+        foreach($this->pluginParams as $param=>$value) {
+            if(is_array($value)) {
+                foreach ($value as &$row) {
+                    if (is_array($row)) $row = 'Array';
+                }
+                unset($row);
+            }
+            $p['pp.'.$param] = is_array($value) ? implode(',',$value) : $value;
+        }
+		//end hack 
+		
+        foreach($this->modxParams   as $param=>$value) { $p['mp.'.$param] = is_array($value) ? implode(',',$value) : $value; };
         foreach($this->themeConfig  as $param=>$arr) {
             if (isset($arr['force'])) $p['tc.' . $param] = $arr['force'];
             elseif (isset($arr['bridged'])) $p['tc.' . $param] = $arr['bridged'];
             else $p['tc.' . $param] = $arr['value'];
-        }
-        foreach($this->gSettingsDefaultValues as $param=>$value) { $p['gd.'.$param] = is_array($value) ? implode(',',$value) : $value; }
-        foreach($this->langArr as $param=>$value)      { $p['l.'.$param] = $value; }
+        };
+        foreach($this->gSettingsDefaultValues as $param=>$value) { $p['gd.'.$param] = is_array($value) ? implode(',',$value) : $value; };
+        foreach($this->langArr as $param=>$value)      { $p['l.'.$param] = $value; };
         return $p;
     }
 

--- a/assets/plugins/qm/qm.inc.php
+++ b/assets/plugins/qm/qm.inc.php
@@ -4,11 +4,11 @@
  *
  * @author      Mikko Lammi, www.maagit.fi, updated by Dmi3yy and Nicola1971
  * @license     GNU General Public License (GPL), http://www.gnu.org/copyleft/gpl.html
- * @version     1.5.12 updated 22/06/2022
+ * @version     1.5.12 updated 16/02/2023
  */
 
 if(!class_exists('Qm')) {
-
+#[AllowDynamicProperties]
 class Qm {
     var $modx;
 

--- a/assets/snippets/DocLister/lib/DLTemplate.class.php
+++ b/assets/snippets/DocLister/lib/DLTemplate.class.php
@@ -5,6 +5,7 @@ if (!class_exists('\\DLTemplate')) {
     /**
      * Class DLTemplate
      */
+	#[AllowDynamicProperties] 
     class DLTemplate
     {
         /**

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -11,6 +11,7 @@ if (!defined('E_USER_DEPRECATED')) {
     define('E_USER_DEPRECATED', 16384);
 }
 
+#[AllowDynamicProperties]
 class DocumentParser
 {
     /**


### PR DESCRIPTION
Сделал правки в код версии 1.4 для работы на php 8.2 на основании правок, сделанных на одном из сайтов.
Основное - добавил параметр #[AllowDynamicProperties] для классов, где выдавало ворнинги. Также сделал хак для версии 8,2 с проверкой на то, что у нас не передается массив в параметрах и приведением к логике как в предыдущих версиях