### PR TITLE
исправить вёрстку страниц удаления tv и шаблона

### DIFF
--- a/core/lang/en/global.php
+++ b/core/lang/en/global.php
@@ -1035,6 +1035,7 @@ $_lang["template_assignedtv_tab"] = 'Assigned Template Variables';
 $_lang["template_code"] = 'Template code (html)';
 $_lang["template_desc"] = 'Description';
 $_lang["template_edit_tab"] = 'Edit Template';
+$_lang["template_inuse"] = 'This template is in use. Please set the documents using the template to another template. Documents using this template:';
 $_lang["template_management_msg"] = 'Choose which Template you wish to edit.';
 $_lang["template_msg"] = 'Create and edit Templates. Changed or new Templates won\'t be visible in your site\'s cached pages until the cache is emptied, however, you can use the preview function on a page to see the Template in action.';
 $_lang["template_name"] = 'Template name';

--- a/manager/processors/delete_category.processor.php
+++ b/manager/processors/delete_category.processor.php
@@ -1,13 +1,13 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_plugin') && !$modx->hasPermission('save_snippet') && !$modx->hasPermission('save_template') && !$modx->hasPermission('save_module')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['catId'])? (int)$_GET['catId'] : 0;
-if ($id==0) {
+$id = isset($_GET['catId']) ? (int) $_GET['catId'] : 0;
+if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
@@ -15,9 +15,9 @@ if ($id==0) {
 $name = \EvolutionCMS\Models\Category::find($id)->category;
 $_SESSION['itemname'] = $name;
 
-include_once(MODX_MANAGER_PATH.'includes/categories.inc.php');
+include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
 deleteCategory($id);
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=76";
+$header = "Location: index.php?a=76";
 header($header);

--- a/manager/processors/delete_eventlog.processor.php
+++ b/manager/processors/delete_eventlog.processor.php
@@ -1,19 +1,19 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_eventlog')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_eventlog')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
 $query = \EvolutionCMS\Models\EventLog::query();
 
-if (isset($_GET['cls']) && $_GET['cls']==1) {
+if (isset($_GET['cls']) && $_GET['cls'] == 1) {
 } else {
-	$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-	if($id==0) {
-		$modx->webAlertAndQuit($_lang["error_no_id"]);
-	}
+    $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+    if ($id == 0) {
+        $modx->webAlertAndQuit($_lang["error_no_id"]);
+    }
     $query = $query->where('id', $id);
 }
 
@@ -21,5 +21,5 @@ if (isset($_GET['cls']) && $_GET['cls']==1) {
 
 $query->delete();
 
-$header="Location: index.php?a=114";
+$header = "Location: index.php?a=114";
 header($header);

--- a/manager/processors/delete_htmlsnippet.processor.php
+++ b/manager/processors/delete_htmlsnippet.processor.php
@@ -1,14 +1,14 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_snippet')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_snippet')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // Set the item name for logger
@@ -16,23 +16,27 @@ $name = EvolutionCMS\Models\SiteHtmlsnippet::findOrFail($id)->name;
 $_SESSION['itemname'] = $name;
 
 // invoke OnBeforeChunkFormDelete event
-$modx->invokeEvent("OnBeforeChunkFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnBeforeChunkFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // delete the chunk.
 EvolutionCMS\Models\SiteHtmlsnippet::destroy($id);
 
 // invoke OnChunkFormDelete event
-$modx->invokeEvent("OnChunkFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnChunkFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // empty cache
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=76&r=2&tab=2";
+$header = "Location: index.php?a=76&r=2&tab=2";
 header($header);

--- a/manager/processors/delete_module.processor.php
+++ b/manager/processors/delete_module.processor.php
@@ -1,14 +1,14 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_module')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_module')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // Set the item name for logger
@@ -16,27 +16,31 @@ $name = EvolutionCMS\Models\SiteModule::select("name")->firstOrFail($id)->name;
 $_SESSION['itemname'] = $name;
 
 // invoke OnBeforeModFormDelete event
-$modx->invokeEvent("OnBeforeModFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnBeforeModFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // delete the module.
 EvolutionCMS\Models\SiteModule::destroy($id);
 // delete the module dependencies.
-EvolutionCMS\Models\SiteModuleDepobj::where('module',$id)->delete();
+EvolutionCMS\Models\SiteModuleDepobj::where('module', $id)->delete();
 // delete the module user group access.
-EvolutionCMS\Models\SiteModuleAccess::where('module',$id)->delete();
+EvolutionCMS\Models\SiteModuleAccess::where('module', $id)->delete();
 
 // invoke OnModFormDelete event
-$modx->invokeEvent("OnModFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnModFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // empty cache
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=76&r=2&tab=5";
+$header = "Location: index.php?a=76&r=2&tab=5";
 header($header);

--- a/manager/processors/delete_plugin.processor.php
+++ b/manager/processors/delete_plugin.processor.php
@@ -1,14 +1,14 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_plugin')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_plugin')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // Set the item name for logger
@@ -16,24 +16,28 @@ $name = EvolutionCMS\Models\SitePlugin::select("name")->firstOrFail($id)->name;
 $_SESSION['itemname'] = $name;
 
 // invoke OnBeforePluginFormDelete event
-$modx->invokeEvent("OnBeforePluginFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnBeforePluginFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // delete the plugin.
 EvolutionCMS\Models\SitePlugin::destroy($id);
 // delete the plugin events.
-EvolutionCMS\Models\SitePluginEvent::where('pluginid',$id)->delete();
+EvolutionCMS\Models\SitePluginEvent::where('pluginid', $id)->delete();
 // invoke OnPluginFormDelete event
-$modx->invokeEvent("OnPluginFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnPluginFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // empty cache
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=76&r=2&tab=4";
+$header = "Location: index.php?a=76&r=2&tab=4";
 header($header);

--- a/manager/processors/delete_snippet.processor.php
+++ b/manager/processors/delete_snippet.processor.php
@@ -1,14 +1,14 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_snippet')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_snippet')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // Set the item name for logger
@@ -16,23 +16,27 @@ $name = EvolutionCMS\Models\SiteSnippet::findOrFail($id)->name;
 $_SESSION['itemname'] = $name;
 
 // invoke OnBeforeSnipFormDelete event
-$modx->invokeEvent("OnBeforeSnipFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnBeforeSnipFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // delete the snippet.
 EvolutionCMS\Models\SiteSnippet::destroy($id);
 
 // invoke OnSnipFormDelete event
-$modx->invokeEvent("OnSnipFormDelete",
-	array(
-		"id"	=> $id
-	));
+$modx->invokeEvent(
+    "OnSnipFormDelete",
+    array(
+        "id" => $id,
+    )
+);
 
 // empty cache
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=76&r=2&tab=3";
+$header = "Location: index.php?a=76&r=2&tab=3";
 header($header);

--- a/manager/processors/delete_template.processor.php
+++ b/manager/processors/delete_template.processor.php
@@ -1,65 +1,62 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_template')) {
+if (!$modx->hasPermission('delete_template')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-if($id == 0) {
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // delete the template, but first check it doesn't have any documents using it
-$siteContents = EvolutionCMS\Models\SiteContent::select('id', 'pagetitle','introtext')->where('template',$id)->where('deleted',0)->get();
-$limit = $siteContents->count();
-if($limit > 0) {
+$siteContents = EvolutionCMS\Models\SiteContent::select('id', 'pagetitle', 'introtext')->where('template', $id)->where('deleted', 0)->get();
+
+$count = $siteContents->count();
+if ($count > 0) {
     include MODX_MANAGER_PATH . "includes/header.inc.php";
     ?>
-
-    <h1><?php echo $_lang['manage_templates']; ?></h1>
+    <h1><?php echo $_lang['templates']; ?></h1>
 
     <div class="tab-page">
         <div class="container container-body">
-
-            <p>This template is in use.<br/>
-                Please set the documents using the template to another template.<br/>
-                Documents using this template:</p>
+            <p><?php echo $_lang['template_inuse'] ?></p>
             <ul>
-                <?php
-                foreach ($siteContents as $row){
-                    echo '<li><span style="width: 200px"><a href="index.php?id=' . $row->id . '&a=27">' . $row->pagetitle . '</a></span>' . ($row->introtext != '' ? ' - ' . $row->introtext : '') . '</li>';
-                }
-                ?>
+<?php
+foreach ($siteContents as $row) {
+        echo '<li><span style="width: 200px"><a href="index.php?id=' . $row->id . '&a=27">' . $row->pagetitle . '</a></span>' . ($row->introtext != '' ? ' - ' . $row->introtext : '') . '</li>';
+    }
+    ?>
             </ul>
         </div>
     </div>
     <?php
-    include_once MODX_MANAGER_PATH . "includes/footer.inc.php";
+include_once MODX_MANAGER_PATH . "includes/footer.inc.php";
     exit;
 }
 $default_template = $modx->getConfig('default_template');
-if($id == $default_template) {
+if ($id == $default_template) {
     $modx->webAlertAndQuit("This template is set as the default template. Please choose a different default template in the MODX configuration before deleting this template.");
 }
 
 // Set the item name for logger
-$name = EvolutionCMS\Models\SiteTemplate::where('id',$id)->first()->templatename;
+$name = EvolutionCMS\Models\SiteTemplate::where('id', $id)->first()->templatename;
 $_SESSION['itemname'] = $name;
 
 // invoke OnBeforeTempFormDelete event
 $modx->invokeEvent("OnBeforeTempFormDelete", array(
-    "id" => $id
+    "id" => $id,
 ));
 
 // delete the document.
 EvolutionCMS\Models\SiteTemplate::where('id', $id)->delete();
 
-EvolutionCMS\Models\SiteTmplvarTemplate::where('templateid',$id)->delete();
+EvolutionCMS\Models\SiteTmplvarTemplate::where('templateid', $id)->delete();
 // invoke OnTempFormDelete event
 $modx->invokeEvent("OnTempFormDelete", array(
-    "id" => $id
+    "id" => $id,
 ));
 
 // empty cache

--- a/manager/processors/delete_tmplvars.processor.php
+++ b/manager/processors/delete_tmplvars.processor.php
@@ -1,57 +1,60 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
-	die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+    die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_template')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_template')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-if($id == 0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 $forced = isset($_GET['force']) ? $_GET['force'] : 0;
 
 // check for relations
-if(!$forced) {
+if (!$forced) {
     $siteTmlvarTemplates = EvolutionCMS\Models\SiteTmplvarContentvalue::with('resource')->where('tmplvarid', '=', $id)->get();
+
     $count = $siteTmlvarTemplates->count();
-    if($count > 0) {
-		include_once MODX_MANAGER_PATH . "includes/header.inc.php";
-		?>
-		<script>
-			var actions = {
-				delete: function() {
-					document.location.href = "index.php?id=<?= $id ?>&a=303&force=1";
-				},
-				cancel: function() {
-					window.location.href = 'index.php?a=301&id=<?= $id ?>';
-				}
-			};
-		</script>
+    if ($count > 0) {
+        include_once MODX_MANAGER_PATH . "includes/header.inc.php";
+        ?>
+        <h1><?php echo $_lang['tmplvars']; ?></h1>
 
-		<h1><?= $_lang['tmplvars'] ?></h1>
+        <script>
+            var actions = {
+                delete: function() {
+                    document.location.href = "index.php?id=<?=$id?>&a=303&force=1";
+                },
+                cancel: function() {
+                    window.location.href = 'index.php?a=301&id=<?=$id?>';
+                }
+            };
+        </script>
+        <?php echo $_style['actionbuttons']['dynamic']['canceldelete']; ?>
 
-		<?= $_style['actionbuttons']['dynamic']['canceldelete'] ?>
-
-		<div class="section">
-			<div class="sectionHeader"><?= $_lang['tmplvars'] ?></div>
-			<div class="sectionBody">
-				<p><?= $_lang['tmplvar_inuse'] ?></p>
-				<ul>
-					<?php
-                    foreach ($siteTmlvarTemplates as $siteTmlvarTemplate) {
-                        echo '<li><span style="width: 200px"><a href="index.php?id=' . $siteTmlvarTemplate->resource->id . '&a=27">' . $siteTmlvarTemplate->resource->pagetitle . '</a></span>' . ($siteTmlvarTemplate->resource->description != '' ? ' - ' . $siteTmlvarTemplate->resource->description : '') . '</li>';
-                    }
-					?>
-				</ul>
-			</div>
-		</div>
-		<?php
-		include_once MODX_MANAGER_PATH . "includes/footer.inc.php";
-		exit;
-	}
+        <div class="tab-page">
+            <div class="container container-body">
+                <p><?php echo $_lang['tmplvar_inuse'] ?></p>
+                <ul>
+<?php
+foreach ($siteTmlvarTemplates as $siteTmlvarTemplate) {
+            echo '<li><span style="width: 200px"><a href="index.php?id=' . $siteTmlvarTemplate->resource->id . '&a=27">' . $siteTmlvarTemplate->resource->pagetitle . '</a></span>' . ($siteTmlvarTemplate->resource->description != '' ? ' - ' . $siteTmlvarTemplate->resource->description : '') . '</li>';
+        }
+        ?>
+                </ul>
+            </div>
+        </div>
+        <?php
+include_once MODX_MANAGER_PATH . "includes/footer.inc.php";
+        exit;
+    }
+    $default_template = $modx->getConfig('default_template');
+    if ($id == $default_template) {
+        $modx->webAlertAndQuit("This template is set as the default template. Please choose a different default template in the MODX configuration before deleting this template.");
+    }
 }
 
 // Set the item name for logger
@@ -60,7 +63,7 @@ $_SESSION['itemname'] = $name;
 
 // invoke OnBeforeTVFormDelete event
 $modx->invokeEvent("OnBeforeTVFormDelete", array(
-	"id" => $id
+    "id" => $id,
 ));
 
 // delete variable
@@ -68,7 +71,7 @@ EvolutionCMS\Models\SiteTmplvar::destroy($id);
 
 // invoke OnTVFormDelete event
 $modx->invokeEvent("OnTVFormDelete", array(
-	"id" => $id
+    "id" => $id,
 ));
 
 // empty cache

--- a/manager/processors/duplicate_htmlsnippet.processor.php
+++ b/manager/processors/duplicate_htmlsnippet.processor.php
@@ -1,30 +1,33 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('new_chunk')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('new_chunk')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // count duplicates
 $htmlsnippet = EvolutionCMS\Models\SiteHtmlsnippet::findOrFail($id);
 $name = $htmlsnippet->name;
-$count = EvolutionCMS\Models\SiteHtmlsnippet::where('name', 'like', $name.' '.$_lang['duplicated_el_suffix'].'%')->count();
-if($count>=1) $count = ' '.($count+1);
-else $count = '';
+$count = EvolutionCMS\Models\SiteHtmlsnippet::where('name', 'like', $name . ' ' . $_lang['duplicated_el_suffix'] . '%')->count();
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 // duplicate htmlsnippet
 $newHtmlsnippet = $htmlsnippet->replicate();
-$newHtmlsnippet->name = $htmlsnippet->name.' '.$_lang['duplicated_el_suffix'].$count;
+$newHtmlsnippet->name = $htmlsnippet->name . ' ' . $_lang['duplicated_el_suffix'] . $count;
 $newHtmlsnippet->push();
 
 $_SESSION['itemname'] = $newHtmlsnippet->name;
 
 // finish duplicating - redirect to new chunk
-$header="Location: index.php?r=2&a=78&id=".$newHtmlsnippet->getKey();
+$header = "Location: index.php?r=2&a=78&id=" . $newHtmlsnippet->getKey();
 header($header);

--- a/manager/processors/duplicate_module.processor.php
+++ b/manager/processors/duplicate_module.processor.php
@@ -1,26 +1,40 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('new_module')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 // count duplicates
 $name = EvolutionCMS\Models\SiteModule::select('name')->findOrFail($id)->name;
 $count = EvolutionCMS\Models\SiteModule::where('name', 'LIKE', "{$name} {$_lang['duplicated_el_suffix']}%'")->count();
-if ($count >= 1) $count = ' ' . ($count + 1);
-else $count = '';
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 // duplicate module
-$module = EvolutionCMS\Models\SiteModule::select("name",
-    "description",  "category", "wrap", "icon", "enable_resource", "resourcefile", "createdon",
-    "editedon", "guid", "enable_sharedparams", "properties", "modulecode")
-    ->findOrFail($id);
+$module = EvolutionCMS\Models\SiteModule::select(
+    "name",
+    "description",
+    "category",
+    "wrap",
+    "icon",
+    "enable_resource",
+    "resourcefile",
+    "createdon",
+    "editedon",
+    "guid",
+    "enable_sharedparams",
+    "properties",
+    "modulecode"
+)->findOrFail($id);
 
 $moduleNew = $module->replicate();
 $moduleNew->name .= " {$_lang['duplicated_el_suffix']}{$count}";
@@ -37,7 +51,6 @@ EvolutionCMS\Models\SiteModuleDepobj::select("module", "resource", "type")
         $item->replicate()->save();
     });
 
-
 // duplicate module user group access
 EvolutionCMS\Models\SiteModuleAccess::select("module", "usergroup")
     ->where('module', $id)->get()
@@ -51,5 +64,5 @@ $name = EvolutionCMS\Models\SiteModule::select('name')->findOrFail($newid)->name
 $_SESSION['itemname'] = $name;
 
 // finish duplicating - redirect to new module
-$header="Location: index.php?r=2&a=108&id=$newid";
+$header = "Location: index.php?r=2&a=108&id=$newid";
 header($header);

--- a/manager/processors/duplicate_plugin.processor.php
+++ b/manager/processors/duplicate_plugin.processor.php
@@ -6,7 +6,7 @@ if (!$modx->hasPermission('new_plugin')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
@@ -14,8 +14,11 @@ if ($id == 0) {
 // count duplicates
 $name = EvolutionCMS\Models\SitePlugin::select('name')->findOrFail($id)->name;
 $count = EvolutionCMS\Models\SitePlugin::where('name', 'LIKE', "{$name} {$_lang['duplicated_el_suffix']}%'")->count();
-if ($count >= 1) $count = ' ' . ($count + 1);
-else $count = '';
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 // duplicate Plugin
 $plugin = EvolutionCMS\Models\SitePlugin::select("name", "description", "disabled", "moduleguid", "plugincode", "properties", "category")

--- a/manager/processors/duplicate_snippet.processor.php
+++ b/manager/processors/duplicate_snippet.processor.php
@@ -1,31 +1,34 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('new_snippet')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('new_snippet')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? (int)$_GET['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 // count duplicates
 $snippet = EvolutionCMS\Models\SiteSnippet::findOrFail($id);
-$name = $snippet ->name;
-$count = EvolutionCMS\Models\SiteSnippet::where('name', 'like', $name.' '.$_lang['duplicated_el_suffix'].'%')->count();
-if($count>=1) $count = ' '.($count+1);
-else $count = '';
+$name = $snippet->name;
+$count = EvolutionCMS\Models\SiteSnippet::where('name', 'like', $name . ' ' . $_lang['duplicated_el_suffix'] . '%')->count();
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 // duplicate Snippet
 $newSnippet = $snippet->replicate();
-$newSnippet->name = $snippet->name.' '.$_lang['duplicated_el_suffix'].$count;
+$newSnippet->name = $snippet->name . ' ' . $_lang['duplicated_el_suffix'] . $count;
 $newSnippet->push();
 
 // Set the item name for logger
 $_SESSION['itemname'] = $newSnippet->name;
 
 // finish duplicating - redirect to new snippet
-$header="Location: index.php?r=2&a=22&id=".$newSnippet->getKey();
+$header = "Location: index.php?r=2&a=22&id=" . $newSnippet->getKey();
 header($header);

--- a/manager/processors/duplicate_template.processor.php
+++ b/manager/processors/duplicate_template.processor.php
@@ -1,12 +1,12 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('new_template')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
@@ -14,8 +14,11 @@ if ($id == 0) {
 // count duplicates
 $name = EvolutionCMS\Models\SiteTemplate::select('templatename')->findOrFail($id)->templatename;
 $count = EvolutionCMS\Models\SiteTemplate::where('templatename', 'LIKE', "{$name} {$_lang['duplicated_el_suffix']}%'")->count();
-if ($count >= 1) $count = ' ' . ($count + 1);
-else $count = '';
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 // duplicate template
 $template = EvolutionCMS\Models\SiteTemplate::select("templatename", "description", "content", "category")
@@ -38,5 +41,5 @@ $name = EvolutionCMS\Models\SiteTemplate::select('templatename')->findOrFail($ne
 $_SESSION['itemname'] = $name;
 
 // finish duplicating - redirect to new template
-$header="Location: index.php?r=2&a=16&id=$newid";
+$header = "Location: index.php?r=2&a=16&id=$newid";
 header($header);

--- a/manager/processors/duplicate_tmplvars.processor.php
+++ b/manager/processors/duplicate_tmplvars.processor.php
@@ -6,7 +6,7 @@ if (!$modx->hasPermission('edit_template')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
@@ -15,9 +15,11 @@ if ($id == 0) {
 $tmplvar = EvolutionCMS\Models\SiteTmplvar::with(['tmplvarAccess', 'tmplvarTemplate', 'tmplvarUserRole'])->findOrFail($id);
 $name = $tmplvar->name;
 $count = EvolutionCMS\Models\SiteTmplvar::where('name', 'like', $name . ' ' . $_lang['duplicated_el_suffix'] . '%')->count();
-if ($count >= 1) $count = ' ' . ($count + 1);
-else $count = '';
-
+if ($count >= 1) {
+    $count = ' ' . ($count + 1);
+} else {
+    $count = '';
+}
 
 $newTmplvar = $tmplvar->replicate();
 $newTmplvar->name = $tmplvar->name . ' ' . $_lang['duplicated_el_suffix'] . $count;

--- a/manager/processors/execute_module.processor.php
+++ b/manager/processors/execute_module.processor.php
@@ -10,7 +10,7 @@ if (!$modx->hasPermission('exec_module')) {
 }
 if (isset($_GET['id'])) {
     if (is_numeric($_GET['id'])) {
-        $id = (int)$_GET['id'];
+        $id = (int) $_GET['id'];
     } else {
         $id = $_GET['id'];
     }

--- a/manager/processors/optimize_table.processor.php
+++ b/manager/processors/optimize_table.processor.php
@@ -1,38 +1,34 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!($modx->hasPermission('settings') && ($modx->hasPermission('logs')||$modx->hasPermission('bk_manager')))) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!($modx->hasPermission('settings') && ($modx->hasPermission('logs') || $modx->hasPermission('bk_manager')))) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
 if (isset($_REQUEST['t'])) {
-
-	if (empty($_REQUEST['t'])) {
-		$modx->webAlertAndQuit($_lang["error_no_optimise_tablename"]);
-	}
-
-	// Set the item name for logger
-	$_SESSION['itemname'] = $_REQUEST['t'];
-
-    if($modx->getDatabase()->getConfig('driver') != 'pgsql'){
-	    $modx->getDatabase()->optimize($_REQUEST['t']);
+    if (empty($_REQUEST['t'])) {
+        $modx->webAlertAndQuit($_lang["error_no_optimise_tablename"]);
     }
 
+    // Set the item name for logger
+    $_SESSION['itemname'] = $_REQUEST['t'];
+
+    if ($modx->getDatabase()->getConfig('driver') != 'pgsql') {
+        $modx->getDatabase()->optimize($_REQUEST['t']);
+    }
 } elseif (isset($_REQUEST['u'])) {
+    if (empty($_REQUEST['u'])) {
+        $modx->webAlertAndQuit($_lang["error_no_truncate_tablename"]);
+    }
 
-	if (empty($_REQUEST['u'])) {
-		$modx->webAlertAndQuit($_lang["error_no_truncate_tablename"]);
-	}
-
-	// Set the item name for logger
-	$_SESSION['itemname'] = $_REQUEST['u'];
+    // Set the item name for logger
+    $_SESSION['itemname'] = $_REQUEST['u'];
     \DB::table(\DB::raw($_REQUEST['u']))->truncate();
-
 } else {
-	$modx->webAlertAndQuit($_lang["error_no_optimise_tablename"]);
+    $modx->webAlertAndQuit($_lang["error_no_optimise_tablename"]);
 }
 
-$mode = (int)get_by_key($_REQUEST, 'mode', 93, 'is_scalar');
-$header="Location: index.php?a={$mode}&s=4";
+$mode = (int) get_by_key($_REQUEST, 'mode', 93, 'is_scalar');
+$header = "Location: index.php?a={$mode}&s=4";
 header($header);

--- a/manager/processors/publish_content.processor.php
+++ b/manager/processors/publish_content.processor.php
@@ -1,29 +1,27 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('save_document') || !$modx->hasPermission('publish_document')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_REQUEST['id'])? (int)$_REQUEST['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 /************webber ********/
-$content=\EvolutionCMS\Models\SiteContent::query()->select('parent', 'pagetitle')->where('id', $id)->first()->toArray();
-$pid=($content['parent']==0?$id:$content['parent']);
+$content = \EvolutionCMS\Models\SiteContent::query()->select('parent', 'pagetitle')->where('id', $id)->first()->toArray();
+$pid = ($content['parent'] == 0 ? $id : $content['parent']);
 
 /************** webber *************/
-$sd=isset($_REQUEST['dir'])?'&dir='.$_REQUEST['dir']:'&dir=DESC';
-$sb=isset($_REQUEST['sort'])?'&sort='.$_REQUEST['sort']:'&sort=createdon';
-$pg=isset($_REQUEST['page'])?'&page='.(int)$_REQUEST['page']:'';
-$add_path=$sd.$sb.$pg;
+$sd = isset($_REQUEST['dir']) ? '&dir=' . $_REQUEST['dir'] : '&dir=DESC';
+$sb = isset($_REQUEST['sort']) ? '&sort=' . $_REQUEST['sort'] : '&sort=createdon';
+$pg = isset($_REQUEST['page']) ? '&page=' . (int) $_REQUEST['page'] : '';
+$add_path = $sd . $sb . $pg;
 
 /***********************************/
-
-
 
 // check permissions on the document
 $udperms = new EvolutionCMS\Legacy\Permissions();
@@ -31,23 +29,23 @@ $udperms->user = $modx->getLoginUserID('mgr');
 $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
-if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+if (!$udperms->checkPermissions()) {
+    $modx->webAlertAndQuit($_lang["access_permission_denied"]);
 }
 
 // update the document
 \EvolutionCMS\Models\SiteContent::query()->find($id)->update(array(
-    'published'   => 1,
-    'pub_date'    => 0,
-    'unpub_date'  => 0,
-    'editedby'    => $modx->getLoginUserID('mgr'),
-    'editedon'    => time(),
+    'published' => 1,
+    'pub_date' => 0,
+    'unpub_date' => 0,
+    'editedby' => $modx->getLoginUserID('mgr'),
+    'editedon' => time(),
     'publishedby' => $modx->getLoginUserID('mgr'),
     'publishedon' => time(),
 ));
 
 // invoke OnDocPublished  event
-$modx->invokeEvent("OnDocPublished",array("docid"=>$id));
+$modx->invokeEvent("OnDocPublished", array("docid" => $id));
 
 // Set the item name for logger
 $_SESSION['itemname'] = $content['pagetitle'];
@@ -55,6 +53,6 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
+$header = "Location: index.php?a=3&id=$pid&r=1" . $add_path;
 
 header($header);

--- a/manager/processors/purge_plugin.processor.php
+++ b/manager/processors/purge_plugin.processor.php
@@ -8,7 +8,6 @@ if (!$modx->hasPermission('delete_plugin')) {
     $e->dumpError();
 }
 
-
 // Get unique list of latest added plugins by highest sql-id
 $plugins = \EvolutionCMS\Models\SitePlugin::query()->select('site_plugins.id')->leftJoin('site_plugins as t2', function ($join) {
     $join->on('site_plugins.name', '=', 't2.name')->on('site_plugins.id', '<', 't2.id');
@@ -24,10 +23,12 @@ $plugins = \EvolutionCMS\Models\SitePlugin::query()->select('site_plugins.id')->
 })->where('site_plugins.disabled', 1);
 
 foreach ($plugins->get()->toArray() as $row) {
-
     $id = $row['id'];
 
-    if (in_array($id, $latestIds)) continue;    // Keep latest version of disabled plugins
+    if (in_array($id, $latestIds)) {
+        continue;
+    }
+    // Keep latest version of disabled plugins
 
     // invoke OnBeforePluginFormDelete event
     $modx->invokeEvent('OnBeforePluginFormDelete', array('id' => $id));

--- a/manager/processors/remove_content.processor.php
+++ b/manager/processors/remove_content.processor.php
@@ -1,18 +1,20 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('delete_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('delete_document')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$ids = \EvolutionCMS\Models\SiteContent::query()->withTrashed()->where('deleted',1)->pluck('id')->toArray();
+$ids = \EvolutionCMS\Models\SiteContent::query()->withTrashed()->where('deleted', 1)->pluck('id')->toArray();
 
 // invoke OnBeforeEmptyTrash event
-$modx->invokeEvent("OnBeforeEmptyTrash",
-						array(
-							"ids"=>$ids
-						));
+$modx->invokeEvent(
+    "OnBeforeEmptyTrash",
+    [
+        "ids" => $ids,
+    ]
+);
 
 // remove the document groups link.
 \EvolutionCMS\Models\DocumentGroup::query()->whereIn('document', $ids)->delete();
@@ -23,15 +25,17 @@ $modx->invokeEvent("OnBeforeEmptyTrash",
 //'undelete' the document.
 \EvolutionCMS\Models\SiteContent::query()->where('deleted', 1)->forceDelete();
 
-	// invoke OnEmptyTrash event
-	$modx->invokeEvent("OnEmptyTrash",
-						array(
-							"ids"=>$ids
-						));
+// invoke OnEmptyTrash event
+$modx->invokeEvent(
+    "OnEmptyTrash",
+    [
+        "ids" => $ids,
+    ]
+);
 
-	// empty cache
-	$modx->clearCache('full');
+// empty cache
+$modx->clearCache('full');
 
-	// finished emptying cache - redirect
-	$header="Location: index.php?a=2&r=1";
-	header($header);
+// finished emptying cache - redirect
+$header = "Location: index.php?a=2&r=1";
+header($header);

--- a/manager/processors/remove_installer.processor.php
+++ b/manager/processors/remove_installer.processor.php
@@ -51,5 +51,3 @@ if ($msg) {
 }
 
 echo "<script>window.location='../#?a=2';</script>";
-
-

--- a/manager/processors/remove_locks.processor.php
+++ b/manager/processors/remove_locks.processor.php
@@ -1,27 +1,29 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 
-if(!isset($_GET['id'])) {
-	if(!$modx->hasPermission('remove_locks')) $modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!isset($_GET['id'])) {
+    if (!$modx->hasPermission('remove_locks')) {
+        $modx->webAlertAndQuit($_lang["error_no_privileges"]);
+    }
 
-	// Remove all locks
+    // Remove all locks
     \EvolutionCMS\Models\ActiveUserLock::query()->truncate();
     \EvolutionCMS\Models\ActiveUser::query()->truncate();
 
-	$header = "Location: index.php?a=2";
-	header($header);
+    $header = "Location: index.php?a=2";
+    header($header);
 } else {
-	// Remove single locks via AJAX / window.onbeforeunload
-	$type = (int)$_GET['type'];
-	$id = (int)$_GET['id'];
-	$includeAllUsers = $modx->hasPermission('remove_locks'); // Enables usage of "unlock"-ajax-button
-	if($type && $id) {
-		$modx->unlockElement($type, $id, $includeAllUsers);
-		echo '1';
-		exit;
-	} else {
-		echo 'No type or id sent with request.';
-	}
+    // Remove single locks via AJAX / window.onbeforeunload
+    $type = (int) $_GET['type'];
+    $id = (int) $_GET['id'];
+    $includeAllUsers = $modx->hasPermission('remove_locks'); // Enables usage of "unlock"-ajax-button
+    if ($type && $id) {
+        $modx->unlockElement($type, $id, $includeAllUsers);
+        echo '1';
+        exit;
+    } else {
+        echo 'No type or id sent with request.';
+    }
 }

--- a/manager/processors/save_content.processor.php
+++ b/manager/processors/save_content.processor.php
@@ -1,5 +1,5 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 $modx = EvolutionCMS();
@@ -16,34 +16,32 @@ $pagetitle = $_POST['pagetitle'];
 $description = $_POST['description'];
 $alias = $_POST['alias'];
 $link_attributes = $_POST['link_attributes'];
-$isfolder = (int)$_POST['isfolder'];
-$richtext = (int)$_POST['richtext'];
-$published = (int)$_POST['published'];
-$parentId = $parent = (int)get_by_key($_POST, 'parent', 0, 'is_scalar');
-$template = (int)$_POST['template'];
-$menuindex = !empty($_POST['menuindex']) ? (int)$_POST['menuindex'] : 0;
-$searchable = (int)$_POST['searchable'];
-$cacheable = (int)$_POST['cacheable'];
-$syncsite = (int)$_POST['syncsite'];
+$isfolder = (int) $_POST['isfolder'];
+$richtext = (int) $_POST['richtext'];
+$published = (int) $_POST['published'];
+$parentId = $parent = (int) get_by_key($_POST, 'parent', 0, 'is_scalar');
+$template = (int) $_POST['template'];
+$menuindex = !empty($_POST['menuindex']) ? (int) $_POST['menuindex'] : 0;
+$searchable = (int) $_POST['searchable'];
+$cacheable = (int) $_POST['cacheable'];
+$syncsite = (int) $_POST['syncsite'];
 $pub_date = $_POST['pub_date'];
 $unpub_date = $_POST['unpub_date'];
 $document_groups = (isset($_POST['chkalldocs']) && $_POST['chkalldocs'] == 'on') ? [] : get_by_key($_POST, 'docgroups', [], 'is_array');
 $type = $_POST['type'];
 $contentType = $_POST['contentType'];
-$contentdispo = (int)$_POST['content_dispo'];
+$contentdispo = (int) $_POST['content_dispo'];
 $longtitle = $_POST['longtitle'];
-$hide_from_tree = (int)$_POST['hide_from_tree'];
+$hide_from_tree = (int) $_POST['hide_from_tree'];
 $menutitle = $_POST['menutitle'];
-$hidemenu = (int)$_POST['hidemenu'];
-$aliasvisible = (int)$_POST['alias_visible'];
+$hidemenu = (int) $_POST['hidemenu'];
+$aliasvisible = (int) $_POST['alias_visible'];
 
 /************* webber ********/
-$sd=isset($_POST['dir']) && strtolower($_POST['dir']) === 'asc' ? '&dir=ASC' : '&dir=DESC';
-$sb=isset($_POST['sort'])?'&sort='.entities($_POST['sort'], $modx->getConfig('modx_charset')):'&sort=pub_date';
-$pg=isset($_POST['page'])?'&page='.(int)$_POST['page']:'';
-$add_path=$sd.$sb.$pg;
-
-
+$sd = isset($_POST['dir']) && strtolower($_POST['dir']) === 'asc' ? '&dir=ASC' : '&dir=DESC';
+$sb = isset($_POST['sort']) ? '&sort=' . entities($_POST['sort'], $modx->getConfig('modx_charset')) : '&sort=pub_date';
+$pg = isset($_POST['page']) ? '&page=' . (int) $_POST['page'] : '';
+$add_path = $sd . $sb . $pg;
 
 $no_esc_pagetitle = $_POST['pagetitle'];
 if (trim($no_esc_pagetitle) == "") {
@@ -53,7 +51,6 @@ if (trim($no_esc_pagetitle) == "") {
         $no_esc_pagetitle = $pagetitle = $_lang['untitled_resource'];
     }
 }
-
 
 $actionToTake = "new";
 if ($_POST['mode'] == '73' || $_POST['mode'] == '27') {
@@ -65,11 +62,10 @@ if ($modx->getConfig('friendly_urls')) {
     // auto assign alias
     if (!$alias && $modx->getConfig('automatic_alias')) {
         $alias = strtolower($modx->stripAlias(trim($pagetitle)));
-        if(!$modx->getConfig('allow_duplicate_alias')) {
-
+        if (!$modx->getConfig('allow_duplicate_alias')) {
             if (\EvolutionCMS\Models\SiteContent::withTrashed()
-                    ->where('id', '<>', $id)
-                    ->where('alias', $alias)->count() > 0) {
+                ->where('id', '<>', $id)
+                ->where('alias', $alias)->count() > 0) {
                 $cnt = 1;
                 $tempAlias = $alias;
 
@@ -82,17 +78,17 @@ if ($modx->getConfig('friendly_urls')) {
                 }
                 $alias = $tempAlias;
             }
-        }else{
+        } else {
             if (\EvolutionCMS\Models\SiteContent::withTrashed()
-                    ->where('id', '<>', $id)
-                    ->where('alias', $alias)
-                    ->where('parent', $parent)->count() > 0) {
+                ->where('id', '<>', $id)
+                ->where('alias', $alias)
+                ->where('parent', $parent)->count() > 0) {
                 $cnt = 1;
                 $tempAlias = $alias;
                 while (\EvolutionCMS\Models\SiteContent::withTrashed()
-                        ->where('id', '<>', $id)
-                        ->where('alias', $tempAlias)
-                        ->where('parent', $parent)->count() > 0) {
+                    ->where('id', '<>', $id)
+                    ->where('alias', $tempAlias)
+                    ->where('parent', $parent)->count() > 0) {
                     $tempAlias = $alias;
                     $tempAlias .= $cnt;
                     $cnt++;
@@ -100,10 +96,8 @@ if ($modx->getConfig('friendly_urls')) {
                 $alias = $tempAlias;
             }
         }
-    }
-
-    // check for duplicate alias name if not allowed
-    elseif ($alias && !$modx->getConfig('allow_duplicate_alias')) {
+    } elseif ($alias && !$modx->getConfig('allow_duplicate_alias')) {
+        // check for duplicate alias name if not allowed
         $alias = $modx->stripAlias($alias);
         $docid = \EvolutionCMS\Models\SiteContent::withTrashed()->select('id')
             ->where('id', '<>', $id)
@@ -122,10 +116,8 @@ if ($modx->getConfig('friendly_urls')) {
                 $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), "index.php?a=4");
             }
         }
-    }
-
-    // strip alias of special characters
-    elseif ($alias) {
+    } elseif ($alias) {
+        // strip alias of special characters
         $alias = $modx->stripAlias($alias);
         $docid = \EvolutionCMS\Models\SiteContent::withTrashed()->select('id')
             ->where('id', '<>', $id)
@@ -142,28 +134,26 @@ if ($modx->getConfig('friendly_urls')) {
             }
         }
     }
-}
-elseif ($alias) {
+} elseif ($alias) {
     $alias = $modx->stripAlias($alias);
 }
 
 // determine published status
-$currentdate = $modx->timestamp((int)get_by_key($_SERVER, 'REQUEST_TIME', 0));
+$currentdate = $modx->timestamp((int) get_by_key($_SERVER, 'REQUEST_TIME', 0));
 
-if (empty ($pub_date)) {
+if (empty($pub_date)) {
     $pub_date = 0;
 } else {
     $pub_date = $modx->toTimeStamp($pub_date);
 
     if ($pub_date < $currentdate) {
         $published = 1;
-    }
-    elseif ($pub_date > $currentdate) {
+    } elseif ($pub_date > $currentdate) {
         $published = 0;
     }
 }
 
-if (empty ($unpub_date)) {
+if (empty($unpub_date)) {
     $unpub_date = 0;
 } else {
     $unpub_date = $modx->toTimeStamp($unpub_date);
@@ -173,22 +163,22 @@ if (empty ($unpub_date)) {
 }
 
 // get document groups for current user
-$tmplvars =[];
+$tmplvars = [];
 $docgrp = array_unique(\EvolutionCMS\Models\MemberGroup::query()
-    ->join('membergroup_access', 'membergroup_access.membergroup', '=', 'member_groups.user_group')
-    ->where('member_groups.member', $modx->getLoginUserID('mgr'))->pluck('documentgroup')->toArray());
+        ->join('membergroup_access', 'membergroup_access.membergroup', '=', 'member_groups.user_group')
+        ->where('member_groups.member', $modx->getLoginUserID('mgr'))->pluck('documentgroup')->toArray());
 
 // ensure that user has not made this document inaccessible to themselves
-if($_SESSION['mgrRole'] != 1 && is_array($document_groups)) {
+if ($_SESSION['mgrRole'] != 1 && is_array($document_groups)) {
     $document_group_list = implode(',', $document_groups);
     $document_group_list = array_filter(explode(',', $document_group_list), 'is_numeric');
-    if(!empty($document_group_list)) {
+    if (!empty($document_group_list)) {
         $count = \EvolutionCMS\Models\MembergroupAccess::query()
             ->join('member_groups', 'membergroup_access.membergroup', '=', 'member_groups.user_group')
             ->whereIn('membergroup_access.documentgroup', $document_group_list)
             ->where('member_groups.member', $_SESSION['mgrInternalKey'])->count('member_groups.id');
 
-        if($count == 0) {
+        if ($count == 0) {
             if ($actionToTake == 'edit') {
                 $modx->getManagerApi()->saveFormValues(27);
                 $modx->webAlertAndQuit($_lang["resource_permissions_error"], "index.php?a=27&id={$id}");
@@ -208,7 +198,7 @@ $tvs = \EvolutionCMS\Models\SiteTmplvar::query()->distinct()
         $join->on('site_tmplvar_contentvalues.contentid', '=', \DB::raw($id));
     })->leftjoin('site_tmplvar_access', 'site_tmplvar_access.tmplvarid', '=', 'site_tmplvars.id')
     ->where('site_tmplvar_templates.templateid', $template)->orderBy('site_tmplvars.rank');
-if($_SESSION['mgrRole']!= 1){
+if ($_SESSION['mgrRole'] != 1) {
     $tvs = $tvs->leftJoin('document_groups', 'site_tmplvar_contentvalues.contentid', '=', 'document_groups.document');
     $tvs = $tvs->where(function ($query) {
         $query->whereNull('site_tmplvar_access.documentgroup')
@@ -228,7 +218,7 @@ foreach ($tvs->toArray() as $row) {
                         "ftp://",
                         "http://",
                         "https://",
-                        "mailto:"
+                        "mailto:",
                     ], "", $tmplvar);
                     $tmplvar = $_POST["tv" . $row['id'] . '_prefix'] . $tmplvar;
                 }
@@ -236,7 +226,7 @@ foreach ($tvs->toArray() as $row) {
             break;
         case 'file':
             $tmplvar = $_POST["tv" . $row['id']] ?? '';
-        break;
+            break;
         default:
             $tmp = get_by_key($_POST, 'tv' . $row['id']);
             if (is_array($tmp)) {
@@ -249,13 +239,13 @@ foreach ($tvs->toArray() as $row) {
             } else {
                 $tmplvar = $tmp;
             }
-        break;
+            break;
     }
     // save value if it was modified
     if ($tmplvar !== '' && $tmplvar !== $row['default_text']) {
-        $tmplvars[$row['id']] = array (
+        $tmplvars[$row['id']] = array(
             $row['id'],
-            $tmplvar
+            $tmplvar,
         );
     } else {
         // Mark the variable for deletion
@@ -271,8 +261,6 @@ if ($actionToTake != "new") {
     }
     $existingDocument = $existingDocument->toArray();
 }
-
-
 
 // check to see if the user is allowed to save the document in the place he wants to save it in
 if ($modx->getConfig('use_udperms') == 1) {
@@ -295,41 +283,40 @@ if ($modx->getConfig('use_udperms') == 1) {
 }
 
 $resourceArray = [
-    "introtext"        => $introtext ,
-    "content"          => $content ,
-    "pagetitle"        => $pagetitle ,
-    "longtitle"        => $longtitle ,
-    "type"             => $type ,
-    "description"      => $description ,
-    "alias"            => $alias ,
-    "link_attributes"  => $link_attributes ,
-    "isfolder"         => $isfolder ,
-    "richtext"         => $richtext ,
-    "published"        => $published ,
-    "parent"           => $parent ,
-    "template"         => $template ,
-    "menuindex"        => $menuindex ,
-    "searchable"       => $searchable ,
-    "cacheable"        => $cacheable ,
-    "pub_date"         => $pub_date ,
-    "unpub_date"       => $unpub_date ,
-    "contentType"      => $contentType ,
-    "content_dispo"    => $contentdispo ,
-    "hide_from_tree"   => $hide_from_tree ,
-    "menutitle"        => $menutitle ,
-    "hidemenu"         => $hidemenu ,
-    "alias_visible"    => $aliasvisible
+    "introtext" => $introtext,
+    "content" => $content,
+    "pagetitle" => $pagetitle,
+    "longtitle" => $longtitle,
+    "type" => $type,
+    "description" => $description,
+    "alias" => $alias,
+    "link_attributes" => $link_attributes,
+    "isfolder" => $isfolder,
+    "richtext" => $richtext,
+    "published" => $published,
+    "parent" => $parent,
+    "template" => $template,
+    "menuindex" => $menuindex,
+    "searchable" => $searchable,
+    "cacheable" => $cacheable,
+    "pub_date" => $pub_date,
+    "unpub_date" => $unpub_date,
+    "contentType" => $contentType,
+    "content_dispo" => $contentdispo,
+    "hide_from_tree" => $hide_from_tree,
+    "menutitle" => $menutitle,
+    "hidemenu" => $hidemenu,
+    "alias_visible" => $aliasvisible,
 ];
 
 switch ($actionToTake) {
-        case 'new' :
-            // invoke OnBeforeDocFormSave event
-            switch($modx->config['docid_incrmnt_method'])
-            {
+    case 'new':
+        // invoke OnBeforeDocFormSave event
+        switch ($modx->config['docid_incrmnt_method']) {
             case '1':
                 $id = \EvolutionCMS\Models\SiteContent::withTrashed()
                     ->leftJoin('site_content as t1', function ($join) {
-                        $join->on(\DB::raw(evo()->getDatabase()->getFullTableName('site_content').'.id +1'), '=', 't1.id');
+                        $join->on(\DB::raw(evo()->getDatabase()->getFullTableName('site_content') . '.id +1'), '=', 't1.id');
                     })
                     ->whereNull('t1.id')->min('site_content.id');
                 $id++;
@@ -338,16 +325,16 @@ switch ($actionToTake) {
             case '2':
                 $id = \EvolutionCMS\Models\SiteContent::max('id');
                 $id++;
-            break;
+                break;
 
             default:
                 $id = '';
-            }
+        }
 
-        $modx->invokeEvent("OnBeforeDocFormSave", array (
+        $modx->invokeEvent("OnBeforeDocFormSave", array(
             'mode' => 'new',
-            'id'   => $id,
-            'doc'  => &$resourceArray
+            'id' => $id,
+            'doc' => &$resourceArray,
         ));
 
         $parentDeleted = $parentId > 0 && empty(\EvolutionCMS\Models\SiteContent::find($parentId));
@@ -364,18 +351,18 @@ switch ($actionToTake) {
         $publishedon = ($published ? $currentdate : 0);
         $publishedby = ($published ? $modx->getLoginUserID('mgr') : 0);
 
-        if ((!empty($pub_date))&&($published)){
-            $publishedon=$pub_date;
+        if ((!empty($pub_date)) && ($published)) {
+            $publishedon = $pub_date;
         }
-
 
         $resourceArray['pub_date'] = $pub_date;
         $resourceArray['publishedon'] = $publishedon;
         $resourceArray['publishedby'] = $publishedby;
         $resourceArray['unpub_date'] = $unpub_date;
 
-        if ($id != '')
+        if ($id != '') {
             $resourceArray["id"] = $id;
+        }
 
         $key = \EvolutionCMS\Models\SiteContent::withTrashed()->create($resourceArray)->getKey();
 
@@ -387,7 +374,6 @@ switch ($actionToTake) {
                 \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->create(array('tmplvarid' => $tvId, 'contentid' => $key, 'value' => $tvVal));
             }
         }
-
 
         // document access permissions
         if ($modx->getConfig('use_udperms') && $parent != 0) {
@@ -402,7 +388,7 @@ switch ($actionToTake) {
             foreach ($document_groups as $value_pair) {
                 // first, split the pair (this is a new document, so ignore the second value
                 [$group] = explode(',', $value_pair); // @see actions/mutate_content.dynamic.php @ line 1138 (permissions list)
-                $group = (int)$group;
+                $group = (int) $group;
                 if ($modx->hasPermission('manage_groups')) {
                     $new_groups[] = ['document_group' => $group, 'document' => $key];
                     $groupsToInsert[] = $group;
@@ -425,7 +411,7 @@ switch ($actionToTake) {
             }
             if (!$modx->hasPermission('manage_groups')) {
                 if (!array_intersect($groupsToInsert, $docgrp)) {
-                    foreach ($groupsParent as $group){
+                    foreach ($groupsParent as $group) {
                         $new_groups[] = ['document_group' => $group, 'document' => $key];
                     }
                 }
@@ -434,10 +420,10 @@ switch ($actionToTake) {
                 \EvolutionCMS\Models\DocumentGroup::query()->insertOrIgnore($new_groups);
             }
         } else {
-            if(!($modx->hasAnyPermissions(['manage_groups', 'manage_document_permissions']))) {
+            if (!($modx->hasAnyPermissions(['manage_groups', 'manage_document_permissions']))) {
                 // inherit document access permissions
-                foreach ($groupsParent as $group){
-                    \EvolutionCMS\Models\DocumentGroup::insert(['document_group'=>$group, 'document'=>$key]);
+                foreach ($groupsParent as $group) {
+                    \EvolutionCMS\Models\DocumentGroup::insert(['document_group' => $group, 'document' => $key]);
                 }
             }
         }
@@ -445,14 +431,14 @@ switch ($actionToTake) {
         // update parent folder status
         if ($resourceArray['parent'] != 0) {
             $fields = array('isfolder' => 1);
-            \EvolutionCMS\Models\SiteContent::withTrashed()->where('id',$resourceArray['parent'])->update(['isfolder'=>1]);
+            \EvolutionCMS\Models\SiteContent::withTrashed()->where('id', $resourceArray['parent'])->update(['isfolder' => 1]);
         }
 
         // invoke OnDocFormSave event
-        $modx->invokeEvent("OnDocFormSave", array (
+        $modx->invokeEvent("OnDocFormSave", array(
             'mode' => 'new',
-            'id'   => $key,
-            'doc'  => $resourceArray
+            'id' => $key,
+            'doc' => $resourceArray,
         ));
 
         // secure web documents - flag as private
@@ -471,246 +457,251 @@ switch ($actionToTake) {
         // redirect/stay options
         if ($_POST['stay'] != '') {
             // weblink
-            if ($_POST['mode'] == "72")
+            if ($_POST['mode'] == "72") {
                 $a = ($_POST['stay'] == '2') ? "27&id=$key" : "72&pid=$parentId";
+            }
+
             // document
-            if ($_POST['mode'] == "4")
+            if ($_POST['mode'] == "4") {
                 $a = ($_POST['stay'] == '2') ? "27&id=$key" : "4&pid=$parentId";
+            }
+
             $header = "Location: index.php?a=" . $a . "&r=1&stay=" . $_POST['stay'];
         } else {
             $header = "Location: index.php?a=3&id=$key&r=1";
         }
 
         if (headers_sent()) {
-            $header = str_replace('Location: ','',$header);
+            $header = str_replace('Location: ', '', $header);
             echo "<script>document.location.href='$header';</script>\n";
         } else {
             header($header);
         }
 
-
         break;
-        case 'edit' :
-            // get the document's current parent
-            $oldparent = $existingDocument['parent'];
-            $doctype = $existingDocument['type'];
+    case 'edit':
+        // get the document's current parent
+        $oldparent = $existingDocument['parent'];
+        $doctype = $existingDocument['type'];
 
-            if ($id == $modx->getConfig('site_start') && $published == 0) {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit("Document is linked to site_start variable and cannot be unpublished!");
-            }
-            $today = $modx->timestamp();
-            if ($id == $modx->getConfig('site_start') && ($pub_date > $today || $unpub_date != "0")) {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit("Document is linked to site_start variable and cannot have publish or unpublish dates set!");
-            }
-            if ($parent == $id) {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit("Document can not be it's own parent!");
-            }
+        if ($id == $modx->getConfig('site_start') && $published == 0) {
+            $modx->getManagerApi()->saveFormValues(27);
+            $modx->webAlertAndQuit("Document is linked to site_start variable and cannot be unpublished!");
+        }
+        $today = $modx->timestamp();
+        if ($id == $modx->getConfig('site_start') && ($pub_date > $today || $unpub_date != "0")) {
+            $modx->getManagerApi()->saveFormValues(27);
+            $modx->webAlertAndQuit("Document is linked to site_start variable and cannot have publish or unpublish dates set!");
+        }
+        if ($parent == $id) {
+            $modx->getManagerApi()->saveFormValues(27);
+            $modx->webAlertAndQuit("Document can not be it's own parent!");
+        }
 
-            $parents = $modx->getParentIds($parent);
-            if (in_array($id, $parents)) {
-                $modx->webAlertAndQuit("Document descendant can not be it's parent!");
-            }
+        $parents = $modx->getParentIds($parent);
+        if (in_array($id, $parents)) {
+            $modx->webAlertAndQuit("Document descendant can not be it's parent!");
+        }
 
-            // check to see document is a folder
-            $child = \EvolutionCMS\Models\SiteContent::withTrashed()->select('id')->where('parent', $id)->first();
-            if (!is_null($child)) {
-                $resourceArray['isfolder'] = 1;
-            }
+        // check to see document is a folder
+        $child = \EvolutionCMS\Models\SiteContent::withTrashed()->select('id')->where('parent', $id)->first();
+        if (!is_null($child)) {
+            $resourceArray['isfolder'] = 1;
+        }
 
-            // set publishedon and publishedby
-            $was_published = $existingDocument['published'];
+        // set publishedon and publishedby
+        $was_published = $existingDocument['published'];
 
-            // keep original publish state, if change is not permitted
-            if (!$modx->hasPermission('publish_document')) {
-                $published = $was_published;
-                $pub_date = 'pub_date';
-                $unpub_date = 'unpub_date';
-            }
+        // keep original publish state, if change is not permitted
+        if (!$modx->hasPermission('publish_document')) {
+            $published = $was_published;
+            $pub_date = 'pub_date';
+            $unpub_date = 'unpub_date';
+        }
 
-            // if it was changed from unpublished to published
-            if (!$was_published && $published) {
-                $publishedon = $currentdate;
-                $publishedby = $modx->getLoginUserID('mgr');
-                }elseif ((!empty($pub_date)&& $pub_date<=$currentdate && $published)) {
-                $publishedon = $pub_date;
-                $publishedby = $modx->getLoginUserID('mgr');
-                   }elseif ($was_published && !$published) {
-                $publishedon = 0;
-                $publishedby = 0;
+        // if it was changed from unpublished to published
+        if (!$was_published && $published) {
+            $publishedon = $currentdate;
+            $publishedby = $modx->getLoginUserID('mgr');
+        } elseif ((!empty($pub_date) && $pub_date <= $currentdate && $published)) {
+            $publishedon = $pub_date;
+            $publishedby = $modx->getLoginUserID('mgr');
+        } elseif ($was_published && !$published) {
+            $publishedon = 0;
+            $publishedby = 0;
+        } else {
+            $publishedon = $existingDocument['publishedon'];
+            $publishedby = $existingDocument['publishedby'];
+        }
+
+        $resourceArray['pub_date'] = $pub_date;
+        $resourceArray['publishedon'] = $publishedon;
+        $resourceArray['publishedby'] = $publishedby;
+
+        // invoke OnBeforeDocFormSave event
+        $modx->invokeEvent("OnBeforeDocFormSave", array(
+            'mode' => 'upd',
+            'id' => $id,
+            'doc' => &$resourceArray,
+        ));
+        $parentDeleted = $parentId > 0 && empty(\EvolutionCMS\Models\SiteContent::find($parentId));
+        if ($parentDeleted) {
+            $resourceArray['deleted'] = 1;
+        }
+        $resource = \EvolutionCMS\Models\SiteContent::withTrashed()->find($id);
+        foreach ($resourceArray as $key => $value) {
+            $resource->{$key} = $value;
+        }
+        $resource->save();
+
+        // update template variables
+        $tvs = \EvolutionCMS\Models\SiteTmplvarContentvalue::select('id', 'tmplvarid')->where('contentid', $id)->get();
+        $tvIds = array();
+        foreach ($tvs as $tv) {
+            $tvIds[$tv->tmplvarid] = $tv->id;
+        }
+        $tvDeletions = array();
+        $tvChanges = array();
+        $tvAdded = array();
+
+        foreach ($tmplvars as $field => $value) {
+            if (!is_array($value)) {
+                if (isset($tvIds[$value])) {
+                    $tvDeletions[] = $tvIds[$value];
+                }
             } else {
-                $publishedon = $existingDocument['publishedon'];
-                $publishedby = $existingDocument['publishedby'];
-            }
-
-            $resourceArray['pub_date'] = $pub_date;
-            $resourceArray['publishedon'] = $publishedon;
-            $resourceArray['publishedby'] = $publishedby;
-
-            // invoke OnBeforeDocFormSave event
-            $modx->invokeEvent("OnBeforeDocFormSave", array (
-                'mode' => 'upd',
-                'id'   => $id,
-                'doc'  => &$resourceArray
-            ));
-            $parentDeleted = $parentId > 0 && empty(\EvolutionCMS\Models\SiteContent::find($parentId));
-            if ($parentDeleted) {
-                $resourceArray['deleted'] = 1;
-            }
-            $resource = \EvolutionCMS\Models\SiteContent::withTrashed()->find($id);
-            foreach($resourceArray as $key=>$value){
-                $resource->{$key} = $value;
-            }
-            $resource->save();
-
-            // update template variables
-            $tvs = \EvolutionCMS\Models\SiteTmplvarContentvalue::select('id', 'tmplvarid')->where('contentid', $id)->get();
-            $tvIds = array ();
-            foreach ($tvs as $tv) {
-                $tvIds[$tv->tmplvarid] = $tv->id;
-            }
-            $tvDeletions = array();
-            $tvChanges = array();
-            $tvAdded = array();
-
-            foreach ($tmplvars as $field => $value) {
-
-                if (!is_array($value)) {
-                    if (isset($tvIds[$value])) $tvDeletions[] = $tvIds[$value];
+                $tvId = $value[0];
+                $tvVal = $value[1];
+                if (isset($tvIds[$tvId])) {
+                    \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->find($tvIds[$tvId])->update(array('tmplvarid' => $tvId, 'contentid' => $id, 'value' => $tvVal));
                 } else {
-                    $tvId = $value[0];
-                    $tvVal = $value[1];
-                    if (isset($tvIds[$tvId])) {
-                        \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->find($tvIds[$tvId])->update(array('tmplvarid' => $tvId, 'contentid' => $id, 'value' => $tvVal));
-                    } else {
-                        \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->create(array('tmplvarid' => $tvId, 'contentid' => $id, 'value' => $tvVal));
-                    }
+                    \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->create(array('tmplvarid' => $tvId, 'contentid' => $id, 'value' => $tvVal));
+                }
+            }
+        }
+
+        if (!empty($tvDeletions)) {
+            \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->whereIn('id', $tvDeletions)->delete();
+        }
+
+        // set document permissions
+        if ($modx->getConfig('use_udperms') == 1 && $modx->hasAnyPermissions(['manage_groups', 'manage_document_permissions']) && is_array($document_groups)) {
+            $new_groups = array();
+            // process the new input
+            foreach ($document_groups as $value_pair) {
+                [$group, $link_id] = explode(',', $value_pair); // @see actions/mutate_content.dynamic.php @ line 1138 (permissions list)
+                if (in_array($group, $docgrp) || $modx->hasPermission('manage_groups')) {
+                    $new_groups[$group] = $link_id;
                 }
             }
 
-            if (!empty($tvDeletions)) {
-                \EvolutionCMS\Models\SiteTmplvarContentvalue::query()->whereIn('id', $tvDeletions)->delete();
-            }
+            // grab the current set of permissions on this document the user can access
+            $documentGroups = \EvolutionCMS\Models\DocumentGroup::select('id', 'document_group')
+                ->where('document', $id)->get();
 
-            // set document permissions
-            if ($modx->getConfig('use_udperms') == 1 && $modx->hasAnyPermissions(['manage_groups', 'manage_document_permissions']) && is_array($document_groups)) {
-                $new_groups = array();
-                // process the new input
-                foreach ($document_groups as $value_pair) {
-                    [$group, $link_id] = explode(',', $value_pair); // @see actions/mutate_content.dynamic.php @ line 1138 (permissions list)
-                    if (in_array($group, $docgrp) || $modx->hasPermission('manage_groups')) {
-                        $new_groups[$group] = $link_id;
-                    }
-                }
-
-                // grab the current set of permissions on this document the user can access
-                $documentGroups = \EvolutionCMS\Models\DocumentGroup::select('id','document_group')
-                    ->where('document', $id)->get();
-
-                $old_groups = array();
-                foreach ($documentGroups as $documentGroup) {
-                    if (in_array($documentGroup->document_group, $docgrp) || $modx->hasPermission('manage_groups')) {
-                        $old_groups[$documentGroup->document_group] = $documentGroup->id;
-                    }
-                }
-                // update the permissions in the database
-                $insertions = $deletions = array();
-                foreach ($new_groups as $group => $link_id) {
-                    if (in_array($group, $docgrp) || $modx->hasPermission('manage_groups')) {
-                        if (array_key_exists($group, $old_groups)) {
-                            unset($old_groups[$group]);
-                            continue;
-                        } elseif ($link_id == 'new') {
-                            $insertions[] = ['document_group' => (int) $group, 'document' => $id];
-                        }
-                    }
-                }
-                if (!empty($insertions)) {
-                    \EvolutionCMS\Models\DocumentGroup::query()->insert($insertions);
-                }
-                if (!$modx->hasPermission('manage_groups')) {
-                    $remainingGroups = \EvolutionCMS\Models\DocumentGroup::select('document_groups.document_group')->whereNotIn('id',
-                        $old_groups)->where('document_groups.document', $id)->pluck('document_group')->toArray();
-                    if (!empty($docgrp) && !array_intersect($docgrp, $remainingGroups)) {
-                        $modx->webAlertAndQuit($_lang["resource_permissions_error"], "index.php?a=27&id={$id}");
-                    }
-                }
-                if (!empty($old_groups)) {
-                    \EvolutionCMS\Models\DocumentGroup::query()->whereIn('id', $old_groups)->delete();
-                }
-                // necessary to remove all permissions as document is public
-                if ((isset($_POST['chkalldocs']) && $_POST['chkalldocs'] == 'on')) {
-                    \EvolutionCMS\Models\DocumentGroup::query()->where('document', $id)->delete();
+            $old_groups = array();
+            foreach ($documentGroups as $documentGroup) {
+                if (in_array($documentGroup->document_group, $docgrp) || $modx->hasPermission('manage_groups')) {
+                    $old_groups[$documentGroup->document_group] = $documentGroup->id;
                 }
             }
-
-            // do the parent stuff
-            if ($resourceArray['parent'] != 0) {
-                $parent = \EvolutionCMS\Models\SiteContent::withTrashed()->find($_REQUEST['parent']);
-                $parent->isfolder = 1;
-                $parent->save();
-            }
-
-            // finished moving the document, now check to see if the old_parent should no longer be a folder
-            $countChildOldParent = \EvolutionCMS\Models\SiteContent::withTrashed()->where('parent', $oldparent)->count();
-
-            if ($countChildOldParent == 0) {
-                $oldParent = \EvolutionCMS\Models\SiteContent::withTrashed()->find($oldparent);
-                $oldParent->isfolder = 0;
-                $oldParent->save();
-            }
-
-
-            // invoke OnDocFormSave event
-            $modx->invokeEvent("OnDocFormSave", array (
-                'mode' => 'upd',
-                'id'   => $id,
-                'doc'  => $resourceArray
-            ));
-
-            // secure web documents - flag as private
-            include MODX_MANAGER_PATH . "includes/secure_web_documents.inc.php";
-            secureWebDocument($id);
-            secureMgrDocument($id);
-
-
-            // Set the item name for logger
-            $_SESSION['itemname'] = $no_esc_pagetitle;
-
-            if ($syncsite == 1) {
-                // empty cache
-                $modx->clearCache('full');
-            }
-
-            if ($_POST['refresh_preview'] == '1')
-                $header = "Location: ".MODX_SITE_URL."index.php?id=$id&z=manprev";
-            else {
-                if ($_POST['stay'] != '2' && $id > 0) {
-                    $modx->unlockElement(7, $id);
-                }
-                if ($_POST['stay'] != '') {
-                    $id = $_REQUEST['id'];
-                    if ($type == "reference") {
-                        // weblink
-                        $a = ($_POST['stay'] == '2') ? "27&id=$id" : "72&pid=$parentId";
-                    } else {
-                        // document
-                        $a = ($_POST['stay'] == '2') ? "27&id=$id" : "4&pid=$parentId";
+            // update the permissions in the database
+            $insertions = $deletions = array();
+            foreach ($new_groups as $group => $link_id) {
+                if (in_array($group, $docgrp) || $modx->hasPermission('manage_groups')) {
+                    if (array_key_exists($group, $old_groups)) {
+                        unset($old_groups[$group]);
+                        continue;
+                    } elseif ($link_id == 'new') {
+                        $insertions[] = ['document_group' => (int) $group, 'document' => $id];
                     }
-                    $header = "Location: index.php?a=" . $a . "&r=1&stay=" . $_POST['stay'].$add_path;
+                }
+            }
+            if (!empty($insertions)) {
+                \EvolutionCMS\Models\DocumentGroup::query()->insert($insertions);
+            }
+            if (!$modx->hasPermission('manage_groups')) {
+                $remainingGroups = \EvolutionCMS\Models\DocumentGroup::select('document_groups.document_group')
+                    ->whereNotIn('id', $old_groups)
+                    ->where('document_groups.document', $id)
+                    ->pluck('document_group')
+                    ->toArray();
+                if (!empty($docgrp) && !array_intersect($docgrp, $remainingGroups)) {
+                    $modx->webAlertAndQuit($_lang["resource_permissions_error"], "index.php?a=27&id={$id}");
+                }
+            }
+            if (!empty($old_groups)) {
+                \EvolutionCMS\Models\DocumentGroup::query()->whereIn('id', $old_groups)->delete();
+            }
+            // necessary to remove all permissions as document is public
+            if ((isset($_POST['chkalldocs']) && $_POST['chkalldocs'] == 'on')) {
+                \EvolutionCMS\Models\DocumentGroup::query()->where('document', $id)->delete();
+            }
+        }
+
+        // do the parent stuff
+        if ($resourceArray['parent'] != 0) {
+            $parent = \EvolutionCMS\Models\SiteContent::withTrashed()->find($_REQUEST['parent']);
+            $parent->isfolder = 1;
+            $parent->save();
+        }
+
+        // finished moving the document, now check to see if the old_parent should no longer be a folder
+        $countChildOldParent = \EvolutionCMS\Models\SiteContent::withTrashed()->where('parent', $oldparent)->count();
+
+        if ($countChildOldParent == 0) {
+            $oldParent = \EvolutionCMS\Models\SiteContent::withTrashed()->find($oldparent);
+            $oldParent->isfolder = 0;
+            $oldParent->save();
+        }
+
+        // invoke OnDocFormSave event
+        $modx->invokeEvent("OnDocFormSave", array(
+            'mode' => 'upd',
+            'id' => $id,
+            'doc' => $resourceArray,
+        ));
+
+        // secure web documents - flag as private
+        include MODX_MANAGER_PATH . "includes/secure_web_documents.inc.php";
+        secureWebDocument($id);
+        secureMgrDocument($id);
+
+        // Set the item name for logger
+        $_SESSION['itemname'] = $no_esc_pagetitle;
+
+        if ($syncsite == 1) {
+            // empty cache
+            $modx->clearCache('full');
+        }
+
+        if ($_POST['refresh_preview'] == '1') {
+            $header = "Location: " . MODX_SITE_URL . "index.php?id=$id&z=manprev";
+        } else {
+            if ($_POST['stay'] != '2' && $id > 0) {
+                $modx->unlockElement(7, $id);
+            }
+            if ($_POST['stay'] != '') {
+                $id = $_REQUEST['id'];
+                if ($type == "reference") {
+                    // weblink
+                    $a = ($_POST['stay'] == '2') ? "27&id=$id" : "72&pid=$parentId";
                 } else {
-                    $header = "Location: index.php?a=3&id=$id&r=1".$add_path;
+                    // document
+                    $a = ($_POST['stay'] == '2') ? "27&id=$id" : "4&pid=$parentId";
                 }
-            }
-            if (headers_sent()) {
-                $header = str_replace('Location: ','',$header);
-                echo "<script>document.location.href='$header';</script>\n";
+                $header = "Location: index.php?a=" . $a . "&r=1&stay=" . $_POST['stay'] . $add_path;
             } else {
-                header($header);
+                $header = "Location: index.php?a=3&id=$id&r=1" . $add_path;
             }
-            break;
-        default :
-            $modx->webAlertAndQuit("No operation set in request.");
+        }
+        if (headers_sent()) {
+            $header = str_replace('Location: ', '', $header);
+            echo "<script>document.location.href='$header';</script>\n";
+        } else {
+            header($header);
+        }
+        break;
+    default:
+        $modx->webAlertAndQuit("No operation set in request.");
 }

--- a/manager/processors/save_htmlsnippet.processor.php
+++ b/manager/processors/save_htmlsnippet.processor.php
@@ -1,5 +1,5 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_chunk')) {
@@ -8,35 +8,35 @@ if (!$modx->hasPermission('save_chunk')) {
 
 if (isset($_GET['disabled'])) {
     $disabled = $_GET['disabled'] == 1 ? 1 : 0;
-    $id = (int)($_REQUEST['id'] ?? 0);
+    $id = (int) ($_REQUEST['id'] ?? 0);
     // Set the item name for logger
     try {
         $chunk = EvolutionCMS\Models\SiteHtmlsnippet::findOrFail($id);
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforeChunkFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
         $_SESSION['itemname'] = $chunk->name;
         $chunk->update(['disabled' => $disabled]);
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnChunkFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
-    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException$e) {
         $modx->webAlertAndQuit($_lang["error_no_id"]);
     }
     // empty cache
     $modx->clearCache('full');
 
     // finished emptying cache - redirect
-    $header="Location: index.php?a=76&tab=2&r=2";
+    $header = "Location: index.php?a=76&tab=2&r=2";
     header($header);
     exit;
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $snippet = $_POST['post'];
 $name = trim($_POST['name']);
 $description = $_POST['description'];
@@ -46,11 +46,11 @@ $createdon = $editedon = time() + $modx->config['server_offset_time'];
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $category = (int)$_POST['categoryid'];
+    $category = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $category = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $category = checkCategory($_POST['newcategory']);
     if (!$category) {
         $category = newCategory($_POST['newcategory']);
@@ -66,26 +66,25 @@ $editor_name = $_POST['which_editor'] != 'none' ? $_POST['which_editor'] : 'none
 
 switch ($_POST['mode']) {
     case '77':
-
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforeChunkFormSave", array(
             "mode" => "new",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for new chunks
-        if (EvolutionCMS\Models\SiteHtmlsnippet::where('name','=',$name)->first()) {
+        if (EvolutionCMS\Models\SiteHtmlsnippet::where('name', '=', $name)->first()) {
             $modx->getManagerApi()->saveFormValues(77);
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['chunk'], $name), "index.php?a=77");
         }
 
         //do stuff to save the new doc
-        $id = EvolutionCMS\Models\SiteHtmlsnippet::create(compact('name', 'description','snippet','locked','category','editor_type','editor_name','disabled','createdon','editedon'))->getKey();
+        $id = EvolutionCMS\Models\SiteHtmlsnippet::create(compact('name', 'description', 'snippet', 'locked', 'category', 'editor_type', 'editor_name', 'disabled', 'createdon', 'editedon'))->getKey();
 
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnChunkFormSave", array(
             "mode" => "new",
-            "id" => $id
+            "id" => $id,
         ));
 
         // Set the item name for logger
@@ -108,11 +107,11 @@ switch ($_POST['mode']) {
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforeChunkFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for chunks
-        if (EvolutionCMS\Models\SiteHtmlsnippet::where('id','!=',$id)->where('name','=',$name)->first()) {
+        if (EvolutionCMS\Models\SiteHtmlsnippet::where('id', '!=', $id)->where('name', '=', $name)->first()) {
             $modx->getManagerApi()->saveFormValues(78);
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['chunk'], $name), "index.php?a=78&id={$id}");
         }
@@ -120,12 +119,12 @@ switch ($_POST['mode']) {
         //do stuff to save the edited doc
         $chunk = EvolutionCMS\Models\SiteHtmlsnippet::find($id);
 
-        $chunk->update(compact('name', 'description','snippet','locked','category','editor_type','editor_name','disabled','editedon'));
+        $chunk->update(compact('name', 'description', 'snippet', 'locked', 'category', 'editor_type', 'editor_name', 'disabled', 'editedon'));
 
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnChunkFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // Set the item name for logger

--- a/manager/processors/save_module.processor.php
+++ b/manager/processors/save_module.processor.php
@@ -1,46 +1,46 @@
 <?php
 global $id, $newid;
 global $use_udperms;
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_module')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
-}else {
+} else {
     $use_udperms = 1;
 }
 
 if (isset($_GET['disabled'])) {
     $disabled = $_GET['disabled'] == 1 ? 1 : 0;
-    $id = (int)($_REQUEST['id'] ?? 0);
+    $id = (int) ($_REQUEST['id'] ?? 0);
     // Set the item name for logger
     try {
         $module = EvolutionCMS\Models\SiteModule::findOrFail($id);
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforeModFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
         $_SESSION['itemname'] = $module->name;
         $module->update(['disabled' => $disabled]);
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnModFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
-    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException$e) {
         $modx->webAlertAndQuit($_lang["error_no_id"]);
     }
     // empty cache
     $modx->clearCache('full');
 
     // finished emptying cache - redirect
-    $header="Location: index.php?a=76&tab=5&r=2";
+    $header = "Location: index.php?a=76&tab=5&r=2";
     header($header);
     exit;
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $name = trim($_POST['name']);
 $description = $_POST['description'];
 $resourcefile = $_POST['resourcefile'];
@@ -59,11 +59,11 @@ $currentdate = time() + $modx->config['server_offset_time'];
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $categoryid = (int)$_POST['categoryid'];
+    $categoryid = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $categoryid = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $categoryid = checkCategory($_POST['newcategory']);
     if (!$categoryid) {
         $categoryid = newCategory($_POST['newcategory']);
@@ -79,7 +79,7 @@ if ($parse_docblock) {
     $name = isset($parsed['name']) ? $parsed['name'] : $name;
     $properties = isset($parsed['properties']) ? $parsed['properties'] : $properties;
     $guid = isset($parsed['guid']) ? $parsed['guid'] : $guid;
-    $enable_sharedparams = isset($parsed['shareparams']) ? (int)$parsed['shareparams'] : $enable_sharedparams;
+    $enable_sharedparams = isset($parsed['shareparams']) ? (int) $parsed['shareparams'] : $enable_sharedparams;
 
     $description = isset($parsed['description']) ? $parsed['description'] : $description;
     $version = isset($parsed['version']) ? '<b>' . $parsed['version'] . '</b> ' : '';
@@ -87,7 +87,7 @@ if ($parse_docblock) {
         $description = $version . trim(preg_replace('/(<b>.+?)+(<\/b>)/i', '', $description));
     }
     if (isset($parsed['modx_category'])) {
-        include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+        include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
         $categoryid = getCategory($parsed['modx_category']);
     }
 }
@@ -96,9 +96,9 @@ switch ($_POST['mode']) {
     case '107':
         // invoke OnBeforeModFormSave event
         $modx->invokeEvent("OnBeforeModFormSave", array(
-                "mode" => "new",
-                "id" => $id
-            ));
+            "mode" => "new",
+            "id" => $id,
+        ));
 
         // disallow duplicate names for new modules
         $count = \EvolutionCMS\Models\SiteModule::query()->where('name', $name)->count();
@@ -123,7 +123,7 @@ switch ($_POST['mode']) {
             'modulecode' => $modulecode,
             'properties' => $properties,
             'createdon' => $currentdate,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
 
         // save user group access permissions
@@ -131,9 +131,9 @@ switch ($_POST['mode']) {
 
         // invoke OnModFormSave event
         $modx->invokeEvent("OnModFormSave", array(
-                "mode" => "new",
-                "id" => $newid
-            ));
+            "mode" => "new",
+            "id" => $newid,
+        ));
 
         // Set the item name for logger
         $_SESSION['itemname'] = $name;
@@ -154,9 +154,9 @@ switch ($_POST['mode']) {
     case '108':
         // invoke OnBeforeModFormSave event
         $modx->invokeEvent("OnBeforeModFormSave", array(
-                "mode" => "upd",
-                "id" => $id
-            ));
+            "mode" => "upd",
+            "id" => $id,
+        ));
 
         // disallow duplicate names for new modules
         $count = \EvolutionCMS\Models\SiteModule::query()->where('name', $name)->where('id', '!=', $id)->count();
@@ -181,7 +181,7 @@ switch ($_POST['mode']) {
             'guid' => $guid,
             'modulecode' => $modulecode,
             'properties' => $properties,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
 
         // save user group access permissions
@@ -189,9 +189,9 @@ switch ($_POST['mode']) {
 
         // invoke OnModFormSave event
         $modx->invokeEvent("OnModFormSave", array(
-                "mode" => "upd",
-                "id" => $id
-            ));
+            "mode" => "upd",
+            "id" => $id,
+        ));
 
         // Set the item name for logger
         $_SESSION['itemname'] = $name;

--- a/manager/processors/save_plugin.processor.php
+++ b/manager/processors/save_plugin.processor.php
@@ -8,35 +8,35 @@ if (!$modx->hasPermission('save_plugin')) {
 
 if (isset($_GET['disabled'])) {
     $disabled = $_GET['disabled'] == 1 ? 1 : 0;
-    $id = (int)($_REQUEST['id'] ?? 0);
+    $id = (int) ($_REQUEST['id'] ?? 0);
     // Set the item name for logger
     try {
         $plugin = EvolutionCMS\Models\SitePlugin::findOrFail($id);
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforePluginFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
         $_SESSION['itemname'] = $plugin->name;
         $plugin->update(['disabled' => $disabled]);
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnPluginFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
-    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException$e) {
         $modx->webAlertAndQuit($_lang["error_no_id"]);
     }
     // empty cache
     $modx->clearCache('full');
 
     // finished emptying cache - redirect
-    $header="Location: index.php?a=76&tab=4&r=2";
+    $header = "Location: index.php?a=76&tab=4&r=2";
     header($header);
     exit;
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $name = trim($_POST['name']);
 $description = $_POST['description'];
 $locked = isset($_POST['locked']) && $_POST['locked'] == 'on' ? '1' : '0';
@@ -50,11 +50,11 @@ $currentdate = time() + $modx->config['server_offset_time'];
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $categoryid = (int)$_POST['categoryid'];
+    $categoryid = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $categoryid = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $categoryid = getCategory($_POST['newcategory']);
 }
 
@@ -75,7 +75,7 @@ if ($parse_docblock) {
         $description = $version . trim(preg_replace('/(<b>.+?)+(<\/b>)/i', '', $description));
     }
     if (isset($parsed['modx_category'])) {
-        include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+        include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
         $categoryid = getCategory($parsed['modx_category']);
     }
 }
@@ -83,11 +83,10 @@ if ($parse_docblock) {
 $eventIds = array();
 switch ($_POST['mode']) {
     case '101':
-
         // invoke OnBeforePluginFormSave event
         $modx->invokeEvent('OnBeforePluginFormSave', array(
             'mode' => 'new',
-            'id' => $id
+            'id' => $id,
         ));
 
         // disallow duplicate names for active plugins
@@ -110,7 +109,7 @@ switch ($_POST['mode']) {
             'properties' => $properties,
             'category' => $categoryid,
             'createdon' => $currentdate,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
 
         // save event listeners
@@ -119,7 +118,7 @@ switch ($_POST['mode']) {
         // invoke OnPluginFormSave event
         $modx->invokeEvent('OnPluginFormSave', array(
             'mode' => 'new',
-            'id' => $newid
+            'id' => $newid,
         ));
 
         // Set the item name for logger
@@ -139,11 +138,10 @@ switch ($_POST['mode']) {
         }
         break;
     case '102':
-
         // invoke OnBeforePluginFormSave event
         $modx->invokeEvent('OnBeforePluginFormSave', array(
             'mode' => 'upd',
-            'id' => $id
+            'id' => $id,
         ));
 
         // disallow duplicate names for active plugins
@@ -165,7 +163,7 @@ switch ($_POST['mode']) {
             'locked' => $locked,
             'properties' => $properties,
             'category' => $categoryid,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
 
         // save event listeners
@@ -174,7 +172,7 @@ switch ($_POST['mode']) {
         // invoke OnPluginFormSave event
         $modx->invokeEvent('OnPluginFormSave', array(
             'mode' => 'upd',
-            'id' => $id
+            'id' => $id,
         ));
 
         // Set the item name for logger

--- a/manager/processors/save_snippet.processor.php
+++ b/manager/processors/save_snippet.processor.php
@@ -1,5 +1,5 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_snippet')) {
@@ -8,35 +8,35 @@ if (!$modx->hasPermission('save_snippet')) {
 
 if (isset($_GET['disabled'])) {
     $disabled = $_GET['disabled'] == 1 ? 1 : 0;
-    $id = (int)($_REQUEST['id'] ?? 0);
+    $id = (int) ($_REQUEST['id'] ?? 0);
     // Set the item name for logger
     try {
         $snippet = EvolutionCMS\Models\SiteSnippet::findOrFail($id);
         // invoke OnBeforeChunkFormSave event
         $modx->invokeEvent("OnBeforeSnipFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
         $_SESSION['itemname'] = $snippet->name;
         $snippet->update(['disabled' => $disabled]);
         // invoke OnChunkFormSave event
         $modx->invokeEvent("OnSnipFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
-    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+    } catch (\Illuminate\Database\Eloquent\ModelNotFoundException$e) {
         $modx->webAlertAndQuit($_lang["error_no_id"]);
     }
     // empty cache
     $modx->clearCache('full');
 
     // finished emptying cache - redirect
-    $header="Location: index.php?a=76&tab=3&r=2";
+    $header = "Location: index.php?a=76&tab=3&r=2";
     header($header);
     exit;
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $snippet = trim($_POST['post']);
 $name = trim($_POST['name']);
 $description = $_POST['description'];
@@ -62,11 +62,11 @@ $parse_docblock = isset($_POST['parse_docblock']) && $_POST['parse_docblock'] ==
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $category = (int)$_POST['categoryid'];
+    $category = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $category = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $category = checkCategory($_POST['newcategory']);
     if (!$category) {
         $category = newCategory($_POST['newcategory']);
@@ -89,33 +89,32 @@ if ($parse_docblock) {
         $description = $version . trim(preg_replace('/(<b>.+?)+(<\/b>)/i', '', $description));
     }
     if (isset($parsed['modx_category'])) {
-        include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+        include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
         $category = getCategory($parsed['modx_category']);
     }
 }
 
 switch ($_POST['mode']) {
     case '23': // Save new snippet
-
         // invoke OnBeforeSnipFormSave event
         $modx->invokeEvent("OnBeforeSnipFormSave", array(
             "mode" => "new",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for new snippets
-        if (EvolutionCMS\Models\SiteSnippet::where('name','=',$name)->first()) {
+        if (EvolutionCMS\Models\SiteSnippet::where('name', '=', $name)->first()) {
             $modx->getManagerApi()->saveFormValues(23);
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['snippet'], $name), "index.php?a=23");
         }
 
         //do stuff to save the new doc
-        $newid = EvolutionCMS\Models\SiteSnippet::create(compact('name', 'description','snippet','moduleguid','locked','properties','category','disabled','createdon','editedon'))->getKey();
+        $newid = EvolutionCMS\Models\SiteSnippet::create(compact('name', 'description', 'snippet', 'moduleguid', 'locked', 'properties', 'category', 'disabled', 'createdon', 'editedon'))->getKey();
 
         // invoke OnSnipFormSave event
         $modx->invokeEvent("OnSnipFormSave", array(
             "mode" => "new",
-            "id" => $newid
+            "id" => $newid,
         ));
 
         // Set the item name for logger
@@ -138,24 +137,24 @@ switch ($_POST['mode']) {
         // invoke OnBeforeSnipFormSave event
         $modx->invokeEvent("OnBeforeSnipFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for snippets
-        if (EvolutionCMS\Models\SiteSnippet::where('id','!=',$id)->where('name','=',$name)->first()) {
+        if (EvolutionCMS\Models\SiteSnippet::where('id', '!=', $id)->where('name', '=', $name)->first()) {
             $modx->getManagerApi()->saveFormValues(22);
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['snippet'], $name), "index.php?a=22&id={$id}");
         }
 
         //do stuff to save the edited doc
-        $siteSnippet= EvolutionCMS\Models\SiteSnippet::find($id);
+        $siteSnippet = EvolutionCMS\Models\SiteSnippet::find($id);
 
-        $siteSnippet->update(compact('name', 'description','snippet','moduleguid','locked','properties','category','disabled','editedon'));
+        $siteSnippet->update(compact('name', 'description', 'snippet', 'moduleguid', 'locked', 'properties', 'category', 'disabled', 'editedon'));
 
         // invoke OnSnipFormSave event
         $modx->invokeEvent("OnSnipFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // Set the item name for logger

--- a/manager/processors/save_template.processor.php
+++ b/manager/processors/save_template.processor.php
@@ -3,7 +3,7 @@
 use EvolutionCMS\Models\SiteTemplate;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_template')) {
@@ -39,23 +39,23 @@ if (isset($_GET['selectable'])) {
     exit;
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $template = $_POST['post'];
 $templatename = trim($_POST['templatename']);
 $templatealias = trim($_POST['templatealias']);
 $description = $_POST['description'];
 $locked = isset($_POST['locked']) && $_POST['locked'] == 'on' ? 1 : 0;
-$selectable = $id == $modx->config['default_template'] ? 1 :    // Force selectable
-    (isset($_POST['selectable']) && $_POST['selectable'] == 'on' ? 1 : 0);
+$selectable = $id == $modx->config['default_template'] ? 1 : // Force selectable
+(isset($_POST['selectable']) && $_POST['selectable'] == 'on' ? 1 : 0);
 $currentdate = time() + $modx->config['server_offset_time'];
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $categoryid = (int)$_POST['categoryid'];
+    $categoryid = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $categoryid = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $categoryid = checkCategory($_POST['newcategory']);
     if (!$categoryid) {
         $categoryid = newCategory($_POST['newcategory']);
@@ -90,11 +90,10 @@ function createBladeFile($templatealias)
 
 switch ($_POST['mode']) {
     case '19':
-
         // invoke OnBeforeTempFormSave event
         $modx->invokeEvent("OnBeforeTempFormSave", array(
             "mode" => "new",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for new templates
@@ -104,8 +103,10 @@ switch ($_POST['mode']) {
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['template'], $templatename), "index.php?a=19");
         }
 
-        if($templatealias == '')
+        if ($templatealias == '') {
             $templatealias = $templatename;
+        }
+
         $templatealias = strtolower($modx->stripAlias(trim($templatealias)));
 
         $count = \EvolutionCMS\Models\SiteTemplate::where('templatealias', $templatealias)->count();
@@ -124,13 +125,13 @@ switch ($_POST['mode']) {
             'selectable' => $selectable,
             'category' => $categoryid,
             'createdon' => $currentdate,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
 
         // invoke OnTempFormSave event
         $modx->invokeEvent("OnTempFormSave", array(
             "mode" => "new",
-            "id" => $newid
+            "id" => $newid,
         ));
         // Set new assigned Tvs
         saveTemplateAccess($newid);
@@ -157,11 +158,10 @@ switch ($_POST['mode']) {
 
         break;
     case '16':
-
         // invoke OnBeforeTempFormSave event
         $modx->invokeEvent("OnBeforeTempFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for templates
@@ -171,8 +171,10 @@ switch ($_POST['mode']) {
             $modx->webAlertAndQuit(sprintf($_lang['duplicate_name_found_general'], $_lang['template'], $templatename), "index.php?a=16&id={$id}");
         }
 
-        if($templatealias == '')
+        if ($templatealias == '') {
             $templatealias = $templatename;
+        }
+
         $templatealias = strtolower($modx->stripAlias(trim($templatealias)));
 
         $count = \EvolutionCMS\Models\SiteTemplate::where('templatealias', $templatealias)->where('id', '!=', $id)->count();
@@ -190,7 +192,7 @@ switch ($_POST['mode']) {
             'locked' => $locked,
             'selectable' => $selectable,
             'category' => $categoryid,
-            'editedon' => $currentdate
+            'editedon' => $currentdate,
         ));
         // Set new assigned Tvs
         saveTemplateAccess($id);
@@ -202,7 +204,7 @@ switch ($_POST['mode']) {
         // invoke OnTempFormSave event
         $modx->invokeEvent("OnTempFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // Set the item name for logger
@@ -221,8 +223,6 @@ switch ($_POST['mode']) {
             $header = "Location: index.php?a=76&r=2";
             header($header);
         }
-
-
         break;
     default:
         $modx->webAlertAndQuit("No operation set in request.");

--- a/manager/processors/save_tmplvars.processor.php
+++ b/manager/processors/save_tmplvars.processor.php
@@ -1,34 +1,34 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
 if (!$modx->hasPermission('save_template')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = (int)$_POST['id'];
+$id = (int) $_POST['id'];
 $name = trim($_POST['name']);
 $description = $_POST['description'];
 $caption = $_POST['caption'];
 $type = $_POST['type'];
 $elements = $_POST['elements'];
 $default_text = $_POST['default_text'];
-$rank = isset ($_POST['rank']) ? $_POST['rank'] : 0;
+$rank = isset($_POST['rank']) ? $_POST['rank'] : 0;
 $display = $_POST['display'];
 $params = $_POST['params'];
 $locked = isset($_POST['locked']) && $_POST['locked'] == 'on' ? 1 : 0;
-$origin = isset($_REQUEST['or']) ? (int)$_REQUEST['or'] : 76;
-$originId = isset($_REQUEST['oid']) ? (int)$_REQUEST['oid'] : null;
+$origin = isset($_REQUEST['or']) ? (int) $_REQUEST['or'] : 76;
+$originId = isset($_REQUEST['oid']) ? (int) $_REQUEST['oid'] : null;
 $currentdate = time() + $modx->config['server_offset_time'];
 $properties = $_POST['properties'];
 
 //Kyle Jaebker - added category support
 if (empty($_POST['newcategory']) && $_POST['categoryid'] > 0) {
-    $categoryid = (int)$_POST['categoryid'];
+    $categoryid = (int) $_POST['categoryid'];
 } elseif (empty($_POST['newcategory']) && $_POST['categoryid'] <= 0) {
     $categoryid = 0;
 } else {
-    include_once(MODX_MANAGER_PATH . 'includes/categories.inc.php');
+    include_once MODX_MANAGER_PATH . 'includes/categories.inc.php';
     $categoryid = checkCategory($_POST['newcategory']);
     if (!$categoryid) {
         $categoryid = newCategory($_POST['newcategory']);
@@ -40,11 +40,10 @@ $caption = $caption != '' ? $caption : $name;
 
 switch ($_POST['mode']) {
     case '300':
-
         // invoke OnBeforeTVFormSave event
         $modx->invokeEvent("OnBeforeTVFormSave", array(
             "mode" => "new",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for new tvs
@@ -74,9 +73,9 @@ switch ($_POST['mode']) {
             'category' => $categoryid,
             'createdon' => $currentdate,
             'editedon' => $currentdate,
-            'properties' => $properties
+            'properties' => $properties,
         );
-        $tmplVar= EvolutionCMS\Models\SiteTmplvar::create($field);
+        $tmplVar = EvolutionCMS\Models\SiteTmplvar::create($field);
         $newid = $tmplVar->getKey();
 
         // save access permissions
@@ -87,7 +86,7 @@ switch ($_POST['mode']) {
         // invoke OnTVFormSave event
         $modx->invokeEvent("OnTVFormSave", array(
             "mode" => "new",
-            "id" => $newid
+            "id" => $newid,
         ));
 
         // Set the item name for logger
@@ -110,7 +109,7 @@ switch ($_POST['mode']) {
         // invoke OnBeforeTVFormSave event
         $modx->invokeEvent("OnBeforeTVFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // disallow duplicate names for tvs
@@ -138,7 +137,7 @@ switch ($_POST['mode']) {
             'locked' => $locked,
             'category' => $categoryid,
             'editedon' => $currentdate,
-            'properties' => $properties
+            'properties' => $properties,
         );
         $tmplVar = EvolutionCMS\Models\SiteTmplvar::findOrFail($id);
         $tmplVar->update($field);
@@ -151,7 +150,7 @@ switch ($_POST['mode']) {
         // invoke OnTVFormSave event
         $modx->invokeEvent("OnTVFormSave", array(
             "mode" => "upd",
-            "id" => $id
+            "id" => $id,
         ));
 
         // Set the item name for logger

--- a/manager/processors/undelete_content.processor.php
+++ b/manager/processors/undelete_content.processor.php
@@ -6,7 +6,7 @@ if (!$modx->hasPermission('delete_document')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_REQUEST['id']) ? (int)$_REQUEST['id'] : 0;
+$id = isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0;
 if ($id == 0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
@@ -20,7 +20,7 @@ if ($parentDeleted) {
 }
 $sd = isset($_REQUEST['dir']) ? '&dir=' . $_REQUEST['dir'] : '&dir=DESC';
 $sb = isset($_REQUEST['sort']) ? '&sort=' . $_REQUEST['sort'] : '&sort=createdon';
-$pg = isset($_REQUEST['page']) ? '&page=' . (int)$_REQUEST['page'] : '';
+$pg = isset($_REQUEST['page']) ? '&page=' . (int) $_REQUEST['page'] : '';
 $add_path = $sd . $sb . $pg;
 
 // check permissions on the document
@@ -46,15 +46,19 @@ array_unshift($documentDeleteIds, $id);
 $site_content_table = (new \EvolutionCMS\Models\SiteContent())->getTable();
 DB::table($site_content_table)
     ->whereIn('id', $documentDeleteIds)
-    ->update(['deleted' => 0,
+    ->update([
+        'deleted' => 0,
         'deletedby' => 0,
-        'deletedon' => 0]);
+        'deletedon' => 0,
+    ]);
 
-$modx->invokeEvent("OnDocFormUnDelete",
+$modx->invokeEvent(
+    "OnDocFormUnDelete",
     array(
         "id" => $id,
-        "children" => $children
-    ));
+        "children" => $children,
+    )
+);
 
 // Set the item name for logger
 $_SESSION['itemname'] = $document->pagetitle;

--- a/manager/processors/unpublish_content.processor.php
+++ b/manager/processors/unpublish_content.processor.php
@@ -1,29 +1,27 @@
 <?php
-if( ! defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
+if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
-if(!$modx->hasPermission('save_document')||!$modx->hasPermission('publish_document')) {
-	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
+if (!$modx->hasPermission('save_document') || !$modx->hasPermission('publish_document')) {
+    $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_REQUEST['id'])? (int)$_REQUEST['id'] : 0;
-if($id==0) {
-	$modx->webAlertAndQuit($_lang["error_no_id"]);
+$id = isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0;
+if ($id == 0) {
+    $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
 
 /************webber ********/
-$content=\EvolutionCMS\Models\SiteContent::query()->select('parent', 'pagetitle')->where('id', $id)->first()->toArray();
-$pid=($content['parent']==0?$id:$content['parent']);
+$content = \EvolutionCMS\Models\SiteContent::query()->select('parent', 'pagetitle')->where('id', $id)->first()->toArray();
+$pid = ($content['parent'] == 0 ? $id : $content['parent']);
 
 /************** webber *************/
-$sd=isset($_REQUEST['dir'])?'&dir='.$_REQUEST['dir']:'&dir=DESC';
-$sb=isset($_REQUEST['sort'])?'&sort='.$_REQUEST['sort']:'&sort=createdon';
-$pg=isset($_REQUEST['page'])?'&page='.(int)$_REQUEST['page']:'';
-$add_path=$sd.$sb.$pg;
+$sd = isset($_REQUEST['dir']) ? '&dir=' . $_REQUEST['dir'] : '&dir=DESC';
+$sb = isset($_REQUEST['sort']) ? '&sort=' . $_REQUEST['sort'] : '&sort=createdon';
+$pg = isset($_REQUEST['page']) ? '&page=' . (int) $_REQUEST['page'] : '';
+$add_path = $sd . $sb . $pg;
 
 /***********************************/
-
-
 
 // check permissions on the document
 $udperms = new EvolutionCMS\Legacy\Permissions();
@@ -31,23 +29,23 @@ $udperms->user = $modx->getLoginUserID('mgr');
 $udperms->document = $id;
 $udperms->role = $_SESSION['mgrRole'];
 
-if(!$udperms->checkPermissions()) {
-	$modx->webAlertAndQuit($_lang["access_permission_denied"]);
+if (!$udperms->checkPermissions()) {
+    $modx->webAlertAndQuit($_lang["access_permission_denied"]);
 }
 
 // update the document
 \EvolutionCMS\Models\SiteContent::query()->find($id)->update(array(
-    'published'   => 0,
-    'pub_date'    => 0,
-    'unpub_date'  => 0,
-    'editedby'    => $modx->getLoginUserID('mgr'),
-    'editedon'    => time(),
+    'published' => 0,
+    'pub_date' => 0,
+    'unpub_date' => 0,
+    'editedby' => $modx->getLoginUserID('mgr'),
+    'editedon' => time(),
     'publishedby' => 0,
     'publishedon' => 0,
 ));
 
 // invoke OnDocUnPublished  event
-$modx->invokeEvent("OnDocUnPublished",array("docid"=>$id));
+$modx->invokeEvent("OnDocUnPublished", array("docid" => $id));
 
 // Set the item name for logger
 $_SESSION['itemname'] = $content['pagetitle'];
@@ -55,6 +53,6 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
+$header = "Location: index.php?a=3&id=$pid&r=1" . $add_path;
 
 header($header);

--- a/manager/processors/user_documents_permissions.class.php
+++ b/manager/processors/user_documents_permissions.class.php
@@ -5,4 +5,5 @@
  */
 class udperms extends EvolutionCMS\Legacy\Permissions
 {
+    //
 }


### PR DESCRIPTION
1) добавлена новая языковая строка `template_inuse` вместо хардкода текста (не забыть добавить в переводы!)
2) исправлен `manager/processors/delete_tmplvars.processor.php` - удаление TV, разметка и код 
3) исправлен `manager/processors/delete_template.processor.php` - удаление шаблона, разметка и код
4) остальные файлы из `manager/processors/` - только форматирование, без изменений