### PR TITLE
Fix for PHP 8.x

### DIFF
--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -893,8 +893,8 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
 											</div>
 											<div id="content_body">
 												<?php
+												$htmlContent = isset($content['content']) ? $content['content'] : '';
 												if(((isset($content['richtext']) && $content['richtext'] == 1) || $modx->manager->action == '4') && $use_editor == 1) {
-													$htmlContent = isset($content['content']) ? $content['content'] : '';
 													?>
 													<div class="section-editor clearfix">
 														<textarea id="ta" name="ta" onchange="documentDirty=true;"><?= $modx->htmlspecialchars($htmlContent) ?></textarea>
@@ -906,7 +906,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
 													$richtexteditorIds[$modx->config['which_editor']][] = 'ta';
 													$richtexteditorOptions[$modx->config['which_editor']]['ta'] = '';
 												} else {
-													echo "\t" . '<div><textarea class="phptextarea" id="ta" name="ta" rows="20" wrap="soft" onchange="documentDirty=true;">', $modx->htmlspecialchars($content['content']), '</textarea></div>' . "\n";
+													echo "\t" . '<div><textarea class="phptextarea" id="ta" name="ta" rows="20" wrap="soft" onchange="documentDirty=true;">', $modx->htmlspecialchars($htmlContent), '</textarea></div>' . "\n";
 												}
 												?>
 											</div>

--- a/manager/includes/tmplvars.inc.php
+++ b/manager/includes/tmplvars.inc.php
@@ -233,7 +233,7 @@ function renderFormElement($field_type, $field_id, $default_text = '', $field_el
 				global $_lang;
 				global $ResourceManagerLoaded;
 				global $content, $use_editor, $which_editor;
-				if(!$ResourceManagerLoaded && !(($content['richtext'] == 1 || $modx->manager->action == 4) && $use_editor == 1 && $which_editor == 3)) {
+				if(!$ResourceManagerLoaded && !(((isset($content['richtext']) && $content['richtext'] == 1) || $modx->manager->action == 4) && $use_editor == 1 && $which_editor == 3)) {
 					/* I didn't understand the meaning of the condition above, so I left it untouched ;-) */
 					$field_html .= "
 						<script type=\"text/javascript\">


### PR DESCRIPTION
Fix warnings when **RichTextEditor is disabled**

When RichTextEditor is disabled in the settings (use_editor=false), the following warnings appear when creating a new article (likely due to undefined variables in PHP 8):

- Warning: Undefined array key "content" in /evocms/manager/actions/mutate_content.dynamic.php on line 909
- Warning: Undefined array key "richtext" in /evocms/manager/includes/tmplvars.inc.php on line 236