### PR TITLE
Update config.inc.tpl - Adapting to a wide range of front-end & back-end environments

### DIFF
--- a/install/config.inc.tpl
+++ b/install/config.inc.tpl
@@ -131,15 +131,19 @@ if (!empty($site_hostnames[0]) && !in_array($site_hostname, $site_hostnames)) {
 // assign site_url
 if (!defined('MODX_SITE_URL')) {
     $secured = (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
+    $user_port = isset($_SERVER['HTTP_X_FORWARDED_PORT']) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $_SERVER['SERVER_PORT']; // Store the port number used by users to connect to the site on the front-end
 //  $site_url = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
-    $site_url = ((isset ($_SERVER['HTTPS']) && ( (strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS']) == '1')) || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
+//  $site_url = ((isset ($_SERVER['HTTPS']) && ( (strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS']) == '1')) || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
+// Replace any occurrence of $_SERVER['SERVER_PORT'] with $user_port from now on
+    $site_url = ((isset ($_SERVER['HTTPS']) && ( (strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS']) == '1')) || $user_port == $https_port || $secured) ? 'https://' : 'http://';
   
     $site_url .= $site_hostname;
-    if ($_SERVER['SERVER_PORT'] != 80) {
-        $site_url = str_replace(':' . $_SERVER['SERVER_PORT'], '', $site_url);
-    } // remove port from HTTP_HOST  
+    if ($user_port != 80) {
+        $site_url = str_replace(':' . $user_port, '', $site_url);
+    } // remove port from HTTP_HOSTe port from HTTP_HOST
 
-    $site_url .= ($_SERVER['SERVER_PORT'] == 80 || (isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port) ? '' : ':' . $_SERVER['SERVER_PORT'];
+//  $site_url .= ($_SERVER['SERVER_PORT'] == 80 || (isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port) ? '' : ':' . $_SERVER['SERVER_PORT'];
+    $site_url .= ($user_port == 80 || (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $user_port == $https_port) ? '' : ':' . $user_port;
     $site_url .= $base_url;
 
     define('MODX_SITE_URL', $site_url);


### PR DESCRIPTION
In some rental server environments or user-configured setups, the front-end runs a web server like Nginx, while the back-end operates Apache on non-standard ports (other than 80 and 443) to handle dynamic language processing, such as PHP, and support .htaccess. In such cases, even though the front-end is using ports 80 and 443, the back-end listening ports were incorrectly added to the `$site_url`, resulting in an inaccessible connection. This issue has been corrected.

** Remark **
We have tested our solution in various environments, including Nginx with PHP-FPM (using a SOCK port) on the same server, Nginx and Apache with PHP-FPM on the same server, and in a setup with separate front-end (Nginx) and back-end (Apache using port 808x).  However, we were not able to accommodate testing in an older environment featuring exclusively Apache and mod_php, as we could not prepare the necessary test setup.