### PR TITLE
Update 2.blade.php

### DIFF
--- a/manager/views/page/2.blade.php
+++ b/manager/views/page/2.blade.php
@@ -253,8 +253,8 @@
         return $feedData;
     });
 
-    $ph['modx_security_notices_content'] = $feedData['modx_security_notices_content'];
-    $ph['modx_news_content'] = $feedData['modx_news_content'];
+    $ph['modx_security_notices_content'] = $feedData['modx_security_notices_content'] ?? [];
+    $ph['modx_news_content'] = $feedData['modx_news_content'] ?? [];
     $ph['theme'] = $modx->getConfig('manager_theme');
     $ph['site_name'] = $modx->getPhpCompat()->entities($modx->getConfig('site_name'));
     $ph['home'] = $_lang['home'];


### PR DESCRIPTION
Под php8.1 в админке лезет ошибка, если в конфигурации строка с адресом rss-ленты пустая.

![Firefox_Screenshot_2023-06-17T22-21-19 278Z](https://github.com/evocms-community/evolution/assets/12978365/a311550a-d41e-4e2d-9c55-9761d15ee20f)

Делаем заглушку-"пустышку" под эти данные, чтобы парсер на них не ругался.