### PR TITLE
Update Core.php

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -5457,7 +5457,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
      */
     public function stripTags($html, $allowed = '')
     {
-        $t = strip_tags($html, $allowed);
+        $t = strip_tags((string)$html, $allowed);
         $t = preg_replace('~\[\*(.*?)\*\]~', '', $t); //tv
         $t = preg_replace('~\[\[(.*?)\]\]~', '', $t); //snippet
         $t = preg_replace('~\[\!(.*?)\!\]~', '', $t); //snippet


### PR DESCRIPTION
fix PHP 8.1(?)

PHP Deprecated: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /.../core/src/Core.php:5459