### PR TITLE
Fix can't read properties of undefined

### DIFF
--- a/manager/media/script/main.js
+++ b/manager/media/script/main.js
@@ -368,7 +368,9 @@ function reset_path(elementName) {
 }
 
 function document_onunload(e) {
-    if (!dontShowWorker) {
+    if (top !== window.top
+        && !dontShowWorker
+    ) {
         top.mainMenu.work();
     }
 }


### PR DESCRIPTION
The error appears when the page is reloaded, when the page is opened not in a frame, but in a separate window.