### PR TITLE
Update mutate_content.dynamic.php

### DIFF
--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -1046,6 +1046,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                         if ($row['type'] == 'richtext' || $row['type'] == 'htmlarea') {
                                             // determine TV-options
                                             $tvOptions = $modx->parseProperties($row['elements']);
+                                            $editor = $modx->config['which_editor'];
                                             if (!empty($tvOptions)) {
                                                 // Allow different Editor with TV-option {"editor":"CKEditor4"} or &editor=Editor;text;CKEditor4
                                                 $editor = isset($tvOptions['editor']) ? $tvOptions['editor'] : $modx->config['which_editor'];


### PR DESCRIPTION
Fix php8 warning. If a weblink used a template that has extra richtext TVs it warned $editor was undefined.