### PR TITLE
Update document.parser.class.inc.php

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3124,7 +3124,7 @@ class DocumentParser
                     break;
                 }
             } else {
-                $id = $this->aliasListing[$id]['parent'];
+                $id = isset($this->aliasListing[$id]['parent']) ? $this->aliasListing[$id]['parent'] : null;
                 if (!$id) {
                     break;
                 }


### PR DESCRIPTION
fix php8 undefined array key warning if editing a resource marked as deleted