### PR TITLE
fix work old sites in php 8.2. Fixed work Shopkeeper and managermanager

### DIFF
--- a/assets/plugins/managermanager/widgets/ddreadonly/ddreadonly.php
+++ b/assets/plugins/managermanager/widgets/ddreadonly/ddreadonly.php
@@ -148,7 +148,7 @@ $mm_ddReadonly.before($mm_ddReadonly.val()).hide();
 				}
 			}
 			
-			if (count($fields) != count($tvs)){
+			if (isset($fields,$tvs) && is_countable($fields) && is_countable($tvs) &&  count($fields) != count($tvs)){
 				//Перебираем поля
 				foreach ($fields as $val){
 					//Если такое поле есть и это не TV

--- a/manager/includes/extenders/deprecated.functions.inc.php
+++ b/manager/includes/extenders/deprecated.functions.inc.php
@@ -250,7 +250,7 @@ class OldFunctions
      * @param $REQUEST_METHOD
      * @return array|bool
      */
-    public function getFormVars($method = "", $prefix = "", $trim = "", $REQUEST_METHOD)
+    public function getFormVars($method = "", $prefix = "", $trim = "", $REQUEST_METHOD = "")
     {
         //  function to retrieve form results into an associative array
         $modx = evolutionCMS();


### PR DESCRIPTION
Две мелкие правки. Устраняют ошибки на старых сайтах с работой Shopkeeper (выводит информацию о Deprecated) и ManagerManager (переставали работать скрипты на странице, где не было TV-параметра, который должен был отображаться только для чтения)