### PR TITLE
Update tracy for php8.3

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -42,7 +42,7 @@
     "predis/predis": "*",
     "rosell-dk/webp-convert": "*",
     "simplepie/simplepie": "^1.8",
-    "tracy/tracy": "2.9.*",
+    "tracy/tracy": "2.10.*",
     "wikimedia/composer-merge-plugin": "2.*"
   },
   "require-dev": {


### PR DESCRIPTION
Tracy 2.10	PHP 8.0 – 8.3	Chrome 64+, Firefox 69+, Safari 15.4+