### PR TITLE
фикс ошибки: PHP Fatal error:  Uncaught TypeError: trim(): Argument #…

### DIFF
--- a/manager/includes/tmplvars.commands.inc.php
+++ b/manager/includes/tmplvars.commands.inc.php
@@ -25,8 +25,8 @@ $BINDINGS = array (
 function ProcessTVCommand($value, $name = '', $docid = '', $src='docform', $tvsArray = array()) {
     $modx = evolutionCMS();
     $docid = (int)$docid > 0 ? (int)$docid : $modx->documentIdentifier;
-    $nvalue = trim($value);
-    if (substr($nvalue, 0, 1) != '@')
+    $nvalue = is_array($value) ? $value : trim($value);
+    if (is_array($nvalue) || substr($nvalue, 0, 1) != '@')
         return $value;
     elseif(isset($modx->config['enable_bindings']) && $modx->config['enable_bindings']!=1 && $src==='docform') {
         return '@Bindings is disabled.';


### PR DESCRIPTION
…1 ($string) must be of type string, array given

Указанная ошибка происходит, если, например, данные пришли из multitv, и там значения для dropdown-списка были заданы не в виде строки с разделителями, а в виде массива.

Сделал, как в версии 3.х, чтобы была проверка на массив.