### PR TITLE
Fix sortableList problems for TVs with html in caption

### DIFF
--- a/manager/actions/mutate_template_tv_rank.dynamic.php
+++ b/manager/actions/mutate_template_tv_rank.dynamic.php
@@ -66,7 +66,7 @@ if ($templateVars->count() > 0) {
         $templatename = $row['templatename'];
         $caption = $row['caption'] != '' ? $row['caption'] : $row['name'];
         $sortableList .= '<li id="item_' . $row['id'] . '"><i class="' . ManagerTheme::getStyle('icon_tv') . '"></i> ' .
-            $caption . ' <small class="protectedNode" style="float:right">[*' . $row['name'] . '*]</small></li>';
+            htmlentities($caption) . ' <small class="protectedNode" style="float:right">[*' . $row['name'] . '*]</small></li>';
     }
     $sortableList .= '</ul></div>';
 } else {

--- a/manager/actions/mutate_template_tv_rank.dynamic.php
+++ b/manager/actions/mutate_template_tv_rank.dynamic.php
@@ -66,7 +66,7 @@ if ($templateVars->count() > 0) {
         $templatename = $row['templatename'];
         $caption = $row['caption'] != '' ? $row['caption'] : $row['name'];
         $sortableList .= '<li id="item_' . $row['id'] . '"><i class="' . ManagerTheme::getStyle('icon_tv') . '"></i> ' .
-            htmlentities($caption) . ' <small class="protectedNode" style="float:right">[*' . $row['name'] . '*]</small></li>';
+            e($caption) . ' <small class="protectedNode" style="float:right">[*' . $row['name'] . '*]</small></li>';
     }
     $sortableList .= '</ul></div>';
 } else {


### PR DESCRIPTION
TV-параметры позволяют добавлять HTML-теги в описание либо имя параметра.

Но при попытке сортировки таких TV-параметров в шаблоне страницы столкнулся с проблемой экранирования.

![image](https://github.com/user-attachments/assets/19282437-041e-4f34-8be6-61e325d667bc)

Следовательно полетел весь DOM списка.

✅ После правки всё в норме.

![image](https://github.com/user-attachments/assets/da66707d-ffe3-4459-9d11-ba857a083bba)
