### PR TITLE
Update SiteContent.php

### DIFF
--- a/core/src/Models/SiteContent.php
+++ b/core/src/Models/SiteContent.php
@@ -388,11 +388,11 @@ class SiteContent extends Model
 
         return $ids;
     }
-
+    
     /**
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
-    public function getTvAttribute(): Collection
+    public function getTvAttribute(): \Illuminate\Support\Collection
     {
         if ($this->tpl->tvs === null) {
             return collect();


### PR DESCRIPTION
Отвалились использования SiteContent вот в таком виде:
```
$doc = SiteContent::find(ваше_ид);
$all_data = $doc->tv->pluck(...); //из-за того, что $doc->tv падает с ошибкой, вызывая getTvAttribute(), где тип возвращаемой коллекции отличается от заявленного типа 
```
(до последней правки этот метод был без типизации, поэтому ошибки не было)

Фикс ошибки с возвратом \Illuminate\Support\Collection вместо Illuminate\Database\Eloquent\Collection.
В этом методе действително возвращается обект другого класса коллекции что в return сщддусе(), что в tpl->tvs->map().