### PR TITLE
Fix: Add missing closing single quote for JavaScript variable evo.locale

### DIFF
--- a/manager/includes/header.inc.php
+++ b/manager/includes/header.inc.php
@@ -114,7 +114,7 @@ if ($modx->config['manager_theme'] == 'default') {
         actions_plus: '<?= $_style['actions_plus'] ?>'
       };
       evo.urlCheckConnectionToServer = '<?= MODX_MANAGER_URL ?>includes/version.inc.php';
-      evo.locale = '<?= evo()->getLocale() ?>
+      evo.locale = '<?= evo()->getLocale() ?>';
     </script>
     <script src="media/script/main.js"></script>
     <script>


### PR DESCRIPTION
In `manager/includes/header.inc.php` on line 117, a JavaScript syntax error exists. The string assigned to the `evo.locale` variable is not properly terminated with a closing single quote.