### PR TITLE
1.4.x - add background to copyrights in login tpl

### DIFF
--- a/manager/media/style/default/login.tpl
+++ b/manager/media/style/default/login.tpl
@@ -225,6 +225,12 @@
                 left: 50%;
                 transform: translate3d(-50%, 0, 0);
             }
+            .copyrights .gpl {
+                padding: .125rem .375rem;
+                background-color: rgba(0, 0, 0, 0.25);
+                border-radius: .25rem;
+                color: #fff;
+            }
         }
         .copyrights a {
             color: #fff

--- a/manager/media/style/default/manager.lockout.tpl
+++ b/manager/media/style/default/manager.lockout.tpl
@@ -194,6 +194,12 @@
                 left: 50%;
                 transform: translate3d(-50%, 0, 0);
                 }
+            .copyrights .gpl {
+                padding: .125rem .375rem;
+                background-color: rgba(0, 0, 0, 0.25);
+                border-radius: .25rem;
+                color: #fff;
+                }
             }
         .copyrights a {
             color: #fff


### PR DESCRIPTION
На светлых фоновых изображениях плохо выглядит копирайт.
<img width="3354" height="2144" alt="image" src="https://github.com/user-attachments/assets/dc1ffdfe-2d77-4cf8-afb1-823114098264" />

Добавил подложку с фоном, аналогичным подложке с формой авторизации.

<img width="3354" height="2146" alt="image" src="https://github.com/user-attachments/assets/1ddf52f9-7630-4a32-8e31-4d805c160355" />
