### PR TITLE
create_command_create_command

### DIFF
--- a/core/src/Console/Commands/MakeCommandCommand.php
+++ b/core/src/Console/Commands/MakeCommandCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace EvolutionCMS\Console\Commands;
+
+use EvolutionCMS\Core;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class MakeCommandCommand extends GeneratorCommand
+{
+    protected $name = 'make:command';
+    protected $description = 'Create a new EvolutionCMS command';
+    protected $type = 'Command';
+
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/command.stub';
+    }
+
+    protected function getPath($name)
+    {
+        $rootNamespace = $this->getCleanRootNamespace();
+        $name = Str::replaceFirst($rootNamespace, '', $name);
+        $name = ltrim($name, '\\');
+
+        if ($rootNamespace === 'EvolutionCMS') {
+            return EVO_CORE_PATH . 'src/' . str_replace('\\', '/', $name) . '.php';
+        } else {
+            return $this->resolveCustomPath($rootNamespace, $name);
+        }
+    }
+
+    protected function getCleanRootNamespace()
+    {
+        $evo = Core::getInstance();
+        $namespace = $evo->getConfig('ControllerNamespace');
+        
+        if (empty($namespace) || trim($namespace) === '') {
+            return 'EvolutionCMS';
+        }
+        $namespace = rtrim($namespace, '\\');
+        $namespace = str_replace('\Controllers', '', $namespace);
+        
+        return $namespace;
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $cleanNamespace = $this->getCleanRootNamespace();
+        return $cleanNamespace . '\Console\Commands';
+    }
+
+    protected function rootNamespace()
+    {
+        return $this->getCleanRootNamespace();
+    }
+    
+    protected function resolveCustomPath($namespace, $className)
+    {
+        $parts = explode('\\', $namespace);
+        if (count($parts) >= 2) {
+            $packageName = $parts[1];
+            $basePath = EVO_CORE_PATH . 'custom/packages/' . strtolower($packageName) . '/src/';
+        } else {
+            $basePath = EVO_CORE_PATH . 'custom/commands/';
+        }
+        $fullPath = $basePath . str_replace('\\', '/', $className) . '.php';
+        $directory = dirname($fullPath);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+        return $fullPath;
+    }
+    
+    protected function qualifyClass($name)
+    {
+        $name = ltrim($name, '\\/');
+        $name = str_replace('/', '\\', $name);
+
+        $rootNamespace = $this->rootNamespace();
+
+        if (Str::startsWith($name, $rootNamespace)) {
+            return $name;
+        }
+        return $this->getDefaultNamespace($rootNamespace) . '\\' . $name;
+    }
+}

--- a/core/src/Console/Commands/stubs/command.stub
+++ b/core/src/Console/Commands/stubs/command.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Console\Command;
+
+class DummyClass extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:name';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        return 0;
+    }
+}

--- a/core/src/Providers/ArtisanServiceProvider.php
+++ b/core/src/Providers/ArtisanServiceProvider.php
@@ -61,6 +61,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'SiteUpdate' => 'command.siteupdate',
         'Extras' => 'command.extras',
         'RouteList' => 'command.route.list',
+        'CommandMake' => 'command.make.command',
     ];
 
     /**
@@ -425,6 +426,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.route.list', function ($app) {
             return new Console\RouteListCommand($app->router);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerCommandMakeCommand()
+    {
+        $this->app->singleton('command.make.command', function ($app) {
+            return new Console\Commands\MakeCommandCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Сделал команду из Laravel, но с оттенком Evolution. Взял за основу настройку ControllerNamespace, если она задана, то файл с командой создается в core\custom\packages. Если не указывать настройку ControllerNamespace, то команды будут создаваться в core\src\Console\Commands.