### PR TITLE
Refactor URL construction for filemanager handling

### DIFF
--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -20,7 +20,10 @@
                 if (modx.getActionFromUrl(href, 2)) {
                     w.history.replaceState(null, d.title, modx.MODX_MANAGER_URL);
                 } else if (modx.getActionFromUrl(href) || modx.main.getQueryVariable('filemanager', href) || /^modules\//.test(href)) {
-                    var url = modx.main.getQueryVariable('filemanager', href) ? modx.MODX_MANAGER_URL + modx.main.getQueryVariable('filemanager', href) + href : href;
+                    var filemanager = modx.main.getQueryVariable('filemanager', href);
+                    var url = filemanager 
+                        ? modx.MODX_MANAGER_URL + filemanager + (href.indexOf('?') !== -1 ? '?' + href.split('?')[1] : '')
+                        : href;
                     if (modx.config.global_tabs) {
                         modx.tabs({ url: url, title: 'blank' });
                     } else if (w.main) {


### PR DESCRIPTION
Как путь двоится:

Шаг 1. Пользователь открывает файловый менеджер в менеджере EVO. Браузер загружает URL вида: /manager/media/browser/mcpuk/browse.php?filemanager=media/browser/mcpuk/browse.php&type=files (or images)

Шаг 2. EVO сохраняет текущий URL в хеш адресной строки: https://site.ru/manager/media/browser/mcpuk/browse.php?filemanager=media/browser/mcpuk/browse.php&type=files

Шаг 3. Страница перезагружается (или открывается заново). init() читает w.location.href и получает этот хеш. После normalizeUrl() имеет: href = "media/browser/mcpuk/browse.php?filemanager=media/browser/mcpuk/browse.php&type=files"

Шаг 4. (Срабатывает баг ) URL строится как:

url = MODX_MANAGER_URL + getQueryVariable('filemanager', href) + href //  = "/manager/"  +  "media/browser/mcpuk/browse.php"  +  "media/browser/mcpuk/browse.php?filemanager=..."

Шаг 5. Запрос уходит на задвоенный URL → 500 ошибка. Но хеш в адресной строке обновляется уже с битым URL.

Шаг 6. При следующей загрузке href содержит уже задвоенный путь → задваивается снова → уже 3 копии → и т.д. Crолько раз открывался менеджер-столько повторений. Далее — снежный ком.

![mcpuk](https://github.com/user-attachments/assets/02ca2cf9-b7c8-497f-90c3-e7f9ee834c66)
