### PR TITLE
fix php8+ warning

### DIFF
--- a/manager/media/browser/mcpuk/lib/class_image_gd.php
+++ b/manager/media/browser/mcpuk/lib/class_image_gd.php
@@ -254,9 +254,13 @@ class image_gd extends image
             $height = @imagesy($image);
             return $image;
 
-        } elseif (is_string($image) &&
-            (false !== (list($width, $height, $t) = @getimagesize($image)))
-        ) {
+        } elseif (is_string($image)) {
+            $info = @getimagesize($image);
+            if ($info === false) {
+                return false;
+            }
+            [$width, $height, $t] = $info;
+    
             switch ($t) {
                 case IMAGETYPE_GIF:
                     $image = @imagecreatefromgif($image);


### PR DESCRIPTION
fix PHP8+
PHP Warning: Cannot use bool as array 
if returning false