### PR TITLE
Добавлена опция для popup

### DIFF
--- a/manager/media/browser/mcpuk/js/browser/folders.js
+++ b/manager/media/browser/mcpuk/js/browser/folders.js
@@ -163,6 +163,10 @@ browser.changeDir = function(dir) {
                 document.title = title;
                 if (browser.opener.TinyMCE)
                     tinyMCEPopup.editor.windowManager.setTitle(window, title);
+                window.parent.postMessage(JSON.stringify({
+                    type: "kcfinder:change-title",
+                    title: title
+				            }), "*");
                 browser.statusDir();
             },
             error: function() {

--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -1834,6 +1834,12 @@
                             modx.dragging(o.el, { wrap: o.wrap, resize: o.resize });
                         }
                         o.el.classList.add('show');
+                        if (typeof o.onshow === 'function') {
+                            var evt = document.createEvent('HTMLEvents');
+							evt.initEvent('show', false, true);
+							o.el.dispatchEvent(evt);
+							o.onshow(evt, o.el);
+                        }
                     },
                     close: function (e) {
                         o.event = e || o.event || w.event;
@@ -1911,7 +1917,8 @@
                             }
                         }
                     },
-                    onclose: function (e, obj) { }
+                    onclose: function (e, obj) { },
+                    onshow: function (e, obj) { }
                 };
                 for (var k in a) {
                     if (a.hasOwnProperty(k) && typeof o[k] !== 'undefined') {


### PR DESCRIPTION
Добавлена опция `onshow` для `popup`
По всей логике она должна быть. Например, когда нужно отловить загрузку iframe, чтобы сделать определённые действия.
Так же в Файловом менеджере `mcpuck` добавлено отправка сообщения при изменении заголовка документа.
Теперь можно отловить через 
```javascript
const eventHandler = (event) => {
	//
	let data = typeof event.data == "string" ? JSON.parse(event.data) : event.data;
	switch(data.type){
		case "kcfinder:change-title":
			console.log(data.title);
			break;
	}
};
window.addEventListener('message', eventHandler)
```
