### PR TITLE
переписать вёрстку страницы показа события

### DIFF
--- a/manager/views/page/eventlog_details.blade.php
+++ b/manager/views/page/eventlog_details.blade.php
@@ -3,11 +3,13 @@
     @push('scripts.top')
         <script type="text/javascript">
             var actions = {
+                // 116 = event delete processor
                 delete: function() {
-                    if(confirm("{{ ManagerTheme::getLexicon('confirm_delete_eventlog') }}") === true) {
+                    if (confirm("{{ ManagerTheme::getLexicon('confirm_delete_eventlog') }}") === true) {
                         document.location.href = "index.php?id=" + document.resource.id.value + "&a=116";
                     }
                 },
+                // 114 = list events
                 cancel: function() {
                     documentDirty = false;
                     document.location.href = 'index.php?a=114';
@@ -23,7 +25,7 @@
     {!! ManagerTheme::getStyle('actionbuttons.dynamic.canceldelete') !!}
 
     <?php /** @var EvolutionCMS\Models\EventLog $log */?>
-    @if($log->exists)
+    @if ($log->exists)
         <form name="resource" method="get">
             <input type="hidden" name="id" value="{{ $log->getKey() }}" />
             <input type="hidden" name="a" value="{{ $controller->getIndex() }}" />
@@ -31,40 +33,52 @@
             <input type="hidden" name="op" value="" />
             <div class="tab-page">
                 <div class="container container-body">
-                    @switch($log->type)
-                        @case(EvolutionCMS\Models\EventLog::TYPE_INFORMATION)
-                            <p><i class="{{ $_style['icon_info_circle'] }} text-info"></i> {{ ManagerTheme::getLexicon('information') }}</p>
-                            @break
-                        @case(EvolutionCMS\Models\EventLog::TYPE_WARNING)
-                            <p><i class="{{ $_style['icon_info_triangle'] }} text-warning"></i> {{ ManagerTheme::getLexicon('warning') }}</p>
-                            @break
-                        @case(EvolutionCMS\Models\EventLog::TYPE_ERROR)
-                            <p><i class="{{ $_style['icon_ban'] }} text-danger"></i> {{ ManagerTheme::getLexicon('error') }}</p>
-                            @break
-                        @default:
-                            <p>N/A</p>
-                    @endswitch
+                    <table class="table data">
+                        <tbody>
+                            <tr>
+                                <td colspan="2">
+                                    @switch($log->type)
+                                        @case(EvolutionCMS\Models\EventLog::TYPE_INFORMATION)
+                                            <i class="{{ $_style['icon_info_circle'] }} text-info"></i>
+                                            {{ ManagerTheme::getLexicon('information') }}
+                                        @break
 
-                    <p><b>{{ $log->source }} - {{ ManagerTheme::getLexicon('eventlog_viewer') }}</b></p>
+                                        @case(EvolutionCMS\Models\EventLog::TYPE_WARNING)
+                                            <i class="{{ $_style['icon_info_triangle'] }} text-warning"></i>
+                                            {{ ManagerTheme::getLexicon('warning') }}
+                                        @break
 
-                    <table class="table">
-                        <tr>
-                            <td width="25%" valign="top">{{ ManagerTheme::getLexicon('event_id') }}:</td>
-                            <td width="25%" valign="top">{{ $log->eventid }}</td>
-                            <td width="25%" valign="top">{{ ManagerTheme::getLexicon('source') }}:</td>
-                            <td width="25%" valign="top">{{ $log->source }}</td>
-                        </tr>
-                        <tr>
-                            <td width="25%" valign="top">{{ ManagerTheme::getLexicon('date') }}:</td>
-                            <td width="25%" valign="top">{{ $log->created_at->format('Y-m-d H:i:s') }}</td>
-                            <td width="25%" valign="top">{{ ManagerTheme::getLexicon('user') }}:</td>
-                            <td width="25%" valign="top">{{ $log->getUser() !== null ? $log->getUser()->username : '-' }}</td>
-                        </tr>
-                        <tr>
-                            <td width="100%" colspan="4"><br />
-                                {!! $log->description !!}
-                            </td>
-                        </tr>
+                                        @case(EvolutionCMS\Models\EventLog::TYPE_ERROR)
+                                            <i class="{{ $_style['icon_ban'] }} text-danger"></i>
+                                            {{ ManagerTheme::getLexicon('error') }}
+                                        @break
+
+                                        @default
+                                            :
+                                            <p>N/A</p>
+                                    @endswitch
+                                </td>
+                            </tr>
+                            <tr>
+                                <th class="w-25">{{ ManagerTheme::getLexicon('event_id') }}</th>
+                                <td>{{ $log->eventid }}</td>
+                            </tr>
+                            <tr>
+                                <th>{{ ManagerTheme::getLexicon('source') }}</th>
+                                <td>{{ $log->source }}</td>
+                            </tr>
+                            <tr>
+                                <th>{{ ManagerTheme::getLexicon('date') }}</th>
+                                <td>{{ $log->created_at->format('Y-m-d H:i:s') }}</td>
+                            </tr>
+                            <tr>
+                                <th>{{ ManagerTheme::getLexicon('user') }}</th>
+                                <td>{{ $log->getUser() !== null ? $log->getUser()->username : '-' }}</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2">{!! $log->description !!}</td>
+                            </tr>
+                        </tbody>
                     </table>
                 </div>
             </div>


### PR DESCRIPTION
Переверстал страницу показа события журнала.

Было:
<img width="1023" height="451" alt="image" src="https://github.com/user-attachments/assets/5325b8b9-e109-440c-bb17-ea20ce83d553" />

Стало:
<img width="1112" height="615" alt="image" src="https://github.com/user-attachments/assets/8465104b-d329-4dc9-ab4a-5cd0aae28121" />
