### PR TITLE
small fix

### DIFF
--- a/assets/plugins/extrascheck/CheckOutdated.class.php
+++ b/assets/plugins/extrascheck/CheckOutdated.class.php
@@ -46,7 +46,7 @@ class CheckOutdated
     public function load($source)
     {
         if (0 === strpos($source, 'http')) {
-            $data = Cache::remember('users', 24 * 60, function () use($source) {
+            $data = Cache::remember('outdated_extras', 24 * 60, function () use($source) {
                 return json_decode(file_get_contents($source), true);
             });
         } else {

--- a/assets/plugins/extrascheck/OutdatedExtrasCheck.plugin.php
+++ b/assets/plugins/extrascheck/OutdatedExtrasCheck.plugin.php
@@ -8,7 +8,8 @@ if (!defined('MODX_BASE_PATH')) {
 $internalKey = $modx->getLoginUserID();
 $sid = $modx->sid;
 $role = (int)$_SESSION['mgrRole'];
-$user = $_SESSION['mgrShortname'];
+$user = (string)($_SESSION['mgrShortname'] ?? '');
+$wdgVisibility = $wdgVisibility ?? 'AdminOnly';
 
 switch (true)
 {
@@ -32,7 +33,7 @@ switch (true)
         }
         $checkOutdated = new CheckOutdated($modx, $modx->event->activePlugin, $_lang);
         $outdated = $checkOutdated->load(
-            'https://raw.githubusercontent.com/evolution-cms/OutdatedExtrasCheck/master/outdated.json'
+            'https://raw.githubusercontent.com/evocms-community/OutdatedExtrasCheck/master/outdated.json'
         );
 
         $out = '';

--- a/assets/plugins/updater/plugin.updater.php
+++ b/assets/plugins/updater/plugin.updater.php
@@ -134,7 +134,7 @@ if ($role != 1 && $wdgVisibility == 'AdminOnly') {
         if ($_GET['q'] == $_SESSION['updatelink']) {
             $tpl = file_get_contents(MODX_BASE_PATH . 'assets/plugins/updater/updater.tpl');
             $tpl = str_replace(['[+update_url+]', '[+site_url+]'], [$_SESSION['updatedata']['url'], MODX_SITE_URL], $tpl);
-            file_put_contents(MODX_BASE_PATH . 'update.php', $tpl);
+            $result = file_put_contents(MODX_BASE_PATH . 'update.php', $tpl);
             if ($result === false) {
                 echo 'Update failed: cannot write to ' . MODX_BASE_PATH . 'update.php';
             } else {


### PR DESCRIPTION
устранение опечатки и  E_WARNING в PHP 8.  
Ссылка на GitHub ведёт на старый репозиторий.
Пропущена $